### PR TITLE
Fix deadline counters

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,7 +26,7 @@ module ApplicationHelper
       full_hours = hours.floor
       minutes = (hours - full_hours) * 60
       full_minutes = minutes.floor
-      "#{full_days} : #{full_hours} : #{full_minutes}"
+      "#{full_days} : #{full_hours.to_s.rjust(2, "0")} : #{full_minutes.to_s.rjust(2, "0")}"
     end
   end
 


### PR DESCRIPTION
Deadline counters were not appropriately padding single-digit entries, which was awkward.

Single-digit hours and minutes are now left-padded. Double-digits are unaffected.