### PR TITLE
Submitters can edit their session proposals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
 - 2.3.0
 services:
 - redis-server
+- postgresql
+addons:
+  postgresql: "9.3"
 bundler_args: "--without development production"
 before_install:
 - export DISPLAY=:99.0

--- a/app/admin/submissions.rb
+++ b/app/admin/submissions.rb
@@ -157,14 +157,14 @@ ActiveAdmin.register Submission do
     status_tag submission.state.to_s.titleize, status_for_submission(submission)
   end
 
-  sidebar :versionate, :partial => "admin/version", :only => :show
+  sidebar :versionate, partial: 'admin/version', only: :show
 
   # Attendee export
   sidebar 'Attendees', except: :index do
     "#{submission.registrants.count} attending"
   end
 
-  action_item :only => [ :edit, :show ] do
+  action_item only: [ :edit, :show ] do
     link_to 'Export attendee list', export_attendees_admin_submission_path(submission)
   end
 
@@ -195,7 +195,7 @@ ActiveAdmin.register Submission do
       end
     end
 
-    attributes_table *(default_attribute_table_rows - [:proposed_updates])
+    attributes_table(*(default_attribute_table_rows - [:proposed_updates]))
 
     panel 'Recent Updates' do
       table_for submission.versions do
@@ -217,7 +217,7 @@ ActiveAdmin.register Submission do
   end
 
   # Notify of venue match
-  action_item :only => :show do
+  action_item only: :show do
     if submission.venue && submission.venue.contact_email && submission.contact_email && submission.venue.contact_name
       link_to('Send venue match email', send_venue_match_email_admin_submission_path(submission), method: :post)
     end
@@ -232,8 +232,7 @@ ActiveAdmin.register Submission do
   end
 
   # Accept proposed session changes
-
-  action_item :only => :show do
+  action_item only: :show do
     if submission.proposed_updates
       link_to('Accept updates', accept_update_admin_submission_path(submission), method: :post)
     end
@@ -246,7 +245,7 @@ ActiveAdmin.register Submission do
   end
 
   # State machine actions
-  action_item :only => :show do
+  action_item only: :show do
     unless submission.on_hold?
       link_to('Place on hold', place_on_hold_admin_submission_path(submission), method: :post)
     end
@@ -258,7 +257,7 @@ ActiveAdmin.register Submission do
     redirect_to admin_submission_path(submission)
   end
 
-  action_item :only => [ :edit, :show ] do
+  action_item only: [ :edit, :show ] do
     unless submission.open_for_voting?
       link_to('Open for voting', open_for_voting_admin_submission_path(submission), method: :post)
     end
@@ -270,7 +269,7 @@ ActiveAdmin.register Submission do
     redirect_to admin_submission_path(submission)
   end
 
-  action_item :only => [ :edit, :show ] do
+  action_item only: [ :edit, :show ] do
     if submission.open_for_voting?
       link_to('Accept', accept_admin_submission_path(submission), method: :post)
     end
@@ -282,7 +281,7 @@ ActiveAdmin.register Submission do
     redirect_to admin_submission_path(submission)
   end
 
-  action_item :only => [ :edit, :show ] do
+  action_item only: [ :edit, :show ] do
     if submission.accepted?
       link_to('Confirm', confirm_admin_submission_path(submission), method: :post)
     end
@@ -294,7 +293,7 @@ ActiveAdmin.register Submission do
     redirect_to admin_submission_path(submission)
   end
 
-  action_item :only =>  [ :edit, :show ] do
+  action_item only: [ :edit, :show ] do
     if submission.open_for_voting?
       link_to('Reject', reject_admin_submission_path(submission), method: :post)
     end
@@ -312,7 +311,7 @@ ActiveAdmin.register Submission do
     redirect_to admin_submission_path(submission)
   end
 
-  action_item :only => [ :edit, :show ] do
+  action_item only: [ :edit, :show ] do
     if submission.open_for_voting?
       link_to('Waitlist', waitlist_admin_submission_path(submission), method: :post)
     end

--- a/app/admin/submissions.rb
+++ b/app/admin/submissions.rb
@@ -183,7 +183,20 @@ ActiveAdmin.register Submission do
   end
 
   show do
-    attributes_table *default_attribute_table_rows
+    if submission.proposed_updates
+      panel 'Proposed Updates' do
+        attributes_table_for submission do
+          submission.proposed_updates.keys.each do |k|
+            row k do
+              submission.proposed_updates[k]
+            end
+          end
+        end
+      end
+    end
+
+    attributes_table *(default_attribute_table_rows - [:proposed_updates])
+
     panel 'Recent Updates' do
       table_for submission.versions do
         column 'Modified at' do |v|
@@ -218,6 +231,19 @@ ActiveAdmin.register Submission do
     redirect_to admin_submission_path(submission)
   end
 
+  # Accept proposed session changes
+
+  action_item :only => :show do
+    if submission.proposed_updates
+      link_to('Accept updates', accept_update_admin_submission_path(submission), method: :post)
+    end
+  end
+
+  member_action :accept_update, method: :post do
+    submission = Submission.find(params[:id])
+    submission.promote_updates
+    redirect_to admin_submission_path(submission)
+  end
 
   # State machine actions
   action_item :only => :show do

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -88,6 +88,7 @@ class SubmissionsController < ApplicationController
     @submission.update(proposed_updates: submission_params)
     if @submission.save
       flash[:notice] = 'Thanks! Your changes have been submitted and are pending review.'
+      @submission.notify_track_chairs_of_update
       redirect_to mine_submissions_path
     else
       respond_with @submission

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -85,9 +85,9 @@ class SubmissionsController < ApplicationController
   end
 
   def update
-    @submission.update(submission_params)
+    @submission.update(proposed_updates: submission_params)
     if @submission.save
-      flash[:notice] = 'Thanks! Your proposal has been updated.'
+      flash[:notice] = 'Thanks! Your changes have been submitted and are pending review.'
       redirect_to mine_submissions_path
     else
       respond_with @submission

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -5,6 +5,7 @@ class SubmissionsController < ApplicationController
   before_action :check_submissions_open, only: [ :new, :create ]
   before_action :authenticate_user!, only: [ :new, :create, :mine ]
   before_action :check_feedback_open, only: [ :index ]
+  before_action :set_submissions, only: [:edit, :update]
 
   def index
     @submissions = Submission.
@@ -80,6 +81,19 @@ class SubmissionsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    @submission.update(submission_params)
+    if @submission.save
+      flash[:notice] = 'Thanks! Your proposal has been updated.'
+      redirect_to mine_submissions_path
+    else
+      respond_with @submission
+    end
+  end
+
   def show
     @submission = Submission.public.
       where(id: params[:id].to_i).
@@ -110,6 +124,10 @@ class SubmissionsController < ApplicationController
 
   def check_feedback_open
     redirect_to feedback_closed_submissions_path unless FeatureToggler.feedback_active?
+  end
+
+  def set_submissions
+    @submission = current_user.submissions.find(params[:id])
   end
 
 end

--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -17,6 +17,13 @@ class NotificationsMailer < ActionMailer::Base
     mail to: chair.email, subject: "A new DSW submission has been received for the #{@track.name} track"
   end
 
+  def notify_of_submission_update(chair, submission)
+    @chair = chair
+    @submission = submission
+    @track = @submission.track
+    mail to: chair.email, subject: "#{@submission.submitter} has proposed an update needing your approval for the #{@track.name} track."
+  end
+
   def confirm_new_submission(submission)
     @submission = submission
     mail to: @submission.contact_email, subject: 'Thanks for submitting a session proposal for Denver Startup Week!'

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -179,6 +179,10 @@ class Submission < ActiveRecord::Base
     event
   end
 
+  def promote_updates
+    update(proposed_updates.merge(proposed_updates: nil))
+  end
+
   private
 
   def notify_track_chairs

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -183,10 +183,16 @@ class Submission < ActiveRecord::Base
     update(proposed_updates.merge(proposed_updates: nil))
   end
 
+  def notify_track_chairs_of_update
+    track.chairs.each do |chair|
+      NotificationsMailer.notify_of_submission_update(chair, self).deliver_now
+    end
+  end
+
   private
 
   def notify_track_chairs
-    self.track.chairs.each do |chair|
+    track.chairs.each do |chair|
       NotificationsMailer.notify_of_new_submission(chair, self).deliver_now
     end
   end

--- a/app/views/notifications_mailer/notify_of_submission_update.text.erb
+++ b/app/views/notifications_mailer/notify_of_submission_update.text.erb
@@ -1,0 +1,19 @@
+Hey there,
+
+An update has been proposed to the following session submission:
+
+<%= @submission.title %>
+
+<%= @submission.description %>
+
+Submitter's notes:
+
+<%= @submission.notes %>
+
+It was submitted by <%= @submission.submitter.name %> (<%= @submission.contact_email %>).
+
+If you approve of these changes, please sign into the admin to accept them.
+
+Cheers,
+
+The DSW Panel Picker Robot

--- a/app/views/submissions/edit.html.slim
+++ b/app/views/submissions/edit.html.slim
@@ -1,0 +1,21 @@
+nav
+  .section-content
+    h1 Edit Submission
+
+section.common.teal
+  .section-content
+    .dash-profile-bar
+    h3 Hello, #{current_user.name}!
+    h6 = link_to 'Return to Dashboard', mine_submissions_path
+
+.section-content
+  = form_for @submission do |f|
+    = f.label :title
+    = f.text_field :title, required: 'required', placeholder: 'Session Title'
+
+    = f.label :description
+    = f.text_area :description, required: 'required', rows: 8, placeholder: 'Session Description (public facing)'
+
+    = f.label :notes
+    = f.text_area :notes, required: 'required', rows: 8, placeholder: 'Session Pitch (for reviewers only)'
+    = f.submit 'Submit'

--- a/app/views/submissions/edit.html.slim
+++ b/app/views/submissions/edit.html.slim
@@ -15,6 +15,9 @@ section.common.sm-centered
       | Before updating your session proposal, please take a minute to read through 
       = link_to 'our FAQs', page_path(page: 'faq'), target: '_blank', class: 'inline-copy-link'
       |  for more information about the submission and selection process.
+      br
+      br
+      | Proposed updates will be sent to the organizing team for approval. We appreciate your patience while we review your changes.
 
     - flash.each do |key, message|
       h6 = message

--- a/app/views/submissions/edit.html.slim
+++ b/app/views/submissions/edit.html.slim
@@ -5,8 +5,22 @@ nav
 section.common.teal
   .section-content
     .dash-profile-bar
-    h3 Hello, #{current_user.name}!
-    h6 = link_to 'Return to Dashboard', mine_submissions_path
+      h3 Hello, #{current_user.name}!
+      h6 = link_to 'Return to Dashboard', mine_submissions_path
+
+section.common.sm-centered
+  .section-content.instruction
+    h6
+      | We encourage you to update the title, description, and/or submitter notes for your session proposal as you see fit. 
+      | Before updating your session proposal, please take a minute to read through 
+      = link_to 'our FAQs', page_path(page: 'faq'), target: '_blank', class: 'inline-copy-link'
+      |  for more information about the submission and selection process.
+
+    - flash.each do |key, message|
+      h6 = message
+
+    - unless @submission.errors.empty?
+      h6 = "Please correct the following errors: #{@submission.errors.full_messages.to_sentence}"
 
 .section-content
   = form_for @submission do |f|

--- a/app/views/submissions/mine.html.slim
+++ b/app/views/submissions/mine.html.slim
@@ -24,7 +24,7 @@ section.common.sm-centered
         .talk-submission
           h6
             | #{submission.title} (#{submission.track.name})
-            = link_to 'Edit', edit_submission_path(submission), class: 'btn'
+            = link_to 'Propose Update', edit_submission_path(submission), class: 'btn'
           /* a href='#' */
           /*   = render partial: 'icons/pencil' */
     - else

--- a/app/views/submissions/mine.html.slim
+++ b/app/views/submissions/mine.html.slim
@@ -24,6 +24,7 @@ section.common.sm-centered
         .talk-submission
           h6
             | #{submission.title} (#{submission.track.name})
+            = link_to 'Edit', edit_submission_path(submission), class: 'btn'
           /* a href='#' */
           /*   = render partial: 'icons/pencil' */
     - else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :submissions, except: [ :edit, :update, :destroy ], path: 'panel-picker', path_names: { new: 'submit' } do
+  resources :submissions, except: [:destroy ], path: 'panel-picker', path_names: { new: 'submit' } do
     collection do
       get :thanks
       get :by_day

--- a/db/migrate/20160802021908_add_proposed_updates_to_submissions.rb
+++ b/db/migrate/20160802021908_add_proposed_updates_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddProposedUpdatesToSubmissions < ActiveRecord::Migration
+  def change
+    add_column :submissions, :proposed_updates, :json
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -487,7 +487,8 @@ CREATE TABLE submissions (
     slides_url character varying,
     video_url character varying,
     cluster_id integer,
-    company_name character varying
+    company_name character varying,
+    proposed_updates json
 );
 
 
@@ -1320,4 +1321,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160719182706');
 INSERT INTO schema_migrations (version) VALUES ('20160720160503');
 
 INSERT INTO schema_migrations (version) VALUES ('20160726164453');
+
+INSERT INTO schema_migrations (version) VALUES ('20160802021908');
 

--- a/spec/features/submitting_spec.rb
+++ b/spec/features/submitting_spec.rb
@@ -86,11 +86,17 @@ feature 'Creating a submission' do
     fill_in 'submission_contact_email', with: 'test2@example.com'
     click_button 'Submit'
 
-    click_on 'Edit'
+    click_on 'Propose Update'
     fill_in 'submission_title', with: 'Updated talk'
     fill_in 'submission_description', with: 'Here is my udpated idea'
     fill_in 'submission_notes', with: 'I have even more things to say now.'
     click_button 'Submit'
+
+    expect(page).to have_content 'Some talk'
+    expect(page).to have_content 'Your changes have been submitted'
+
+    Submission.last.promote_updates
+    visit page.current_path
 
     expect(page).to have_content 'Updated talk'
     expect(page).to_not have_content 'Some talk'

--- a/spec/features/submitting_spec.rb
+++ b/spec/features/submitting_spec.rb
@@ -69,4 +69,31 @@ feature 'Creating a submission' do
     expect(page).to have_content('Email has already been taken')
   end
 
+  scenario 'User edits an existing submission' do
+    visit '/panel-picker/mine' # Can't click on the homepage for some reason
+    click_on 'Register for an account'
+    fill_in 'Name', with: 'New Guy'
+    fill_in 'E-mail Address', with: 'test@example.com'
+    fill_in 'Password', with: 'password', match: :prefer_exact
+    fill_in 'Confirm Password', with: 'password', match: :prefer_exact
+
+    click_on 'Sign Up'
+    click_on 'Submit a New Proposal'
+    select 'Bizness', from: 'submission_track_id'
+    fill_in 'submission_title', with: 'Some talk'
+    fill_in 'submission_description', with: 'I am going to give a talk.'
+    fill_in 'submission_notes', with: 'Please pick my talk.'
+    fill_in 'submission_contact_email', with: 'test2@example.com'
+    click_button 'Submit'
+
+    click_on 'Edit'
+    fill_in 'submission_title', with: 'Updated talk'
+    fill_in 'submission_description', with: 'Here is my udpated idea'
+    fill_in 'submission_notes', with: 'I have even more things to say now.'
+    click_button 'Submit'
+
+    expect(page).to have_content 'Updated talk'
+    expect(page).to_not have_content 'Some talk'
+  end
+
 end


### PR DESCRIPTION
Limited to title, description, and presenter notes only. User edits kicked over to ActiveAdmin for approval and must be manually accepted before going live on the site. An email is triggered to track chairs whenever someone makes a suggested update.

Closes #17