### PR TITLE
Fix HelpScout nil errors

### DIFF
--- a/app/views/helpscout_hooks/_helpscout_fragment.html.erb
+++ b/app/views/helpscout_hooks/_helpscout_fragment.html.erb
@@ -3,8 +3,10 @@
   Session Submissions
 </h4>
 <ul>
-  <%- @user.submissions.each do |submission| %>
-    <li><%= link_to "#{submission.title} (#{submission.year})", admin_submission_url(submission) %></li>
+  <%- if @user %>
+    <%- @user.submissions.each do |submission| %>
+      <li><%= link_to "#{submission.title} (#{submission.year})", admin_submission_url(submission) %></li>
+    <%- end %>
   <%- end %>
 </ul>
 <h4>
@@ -12,7 +14,9 @@
   Registration History
 </h4>
 <p>
-  <%- @user.registrations.each do |registration| %>
-    <span class="badge"><%= registration.year %></span>
+  <%- if @user %>
+    <%- @user.registrations.each do |registration| %>
+      <span class="badge"><%= registration.year %></span>
+    <%- end %>
   <%- end %>
 </p>


### PR DESCRIPTION
Add guard clause so that helpscout doesn't blow up trying to pull submissions or registration for a non-existent user