### PR TITLE
Assign extra attributes to submitters in Emma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :test do
   gem 'test_after_commit'
   gem 'email_spec', '~> 2.1.0'
   gem 'webmock'
+  gem 'factory_girl_rails'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,11 @@ GEM
       mail (~> 2.6.3)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     ffi (1.9.10)
     font_assets (0.1.7)
       rack
@@ -392,6 +397,7 @@ DEPENDENCIES
   dotenv-rails
   email_spec (~> 2.1.0)
   emma!
+  factory_girl_rails
   font_assets
   gemoji
   github-markdown
@@ -444,5 +450,8 @@ DEPENDENCIES
   utf8-cleaner
   webmock
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.12.3
+   1.12.5

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :user do
     name 'Erlich Bachmann'
     password 'password'
-    password_confirmation 'password'
+    password_confirmation { password }
     sequence(:email) { |n| "user#{n}@example.com" }
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :user do
+    name 'Erlich Bachmann'
+    password 'password'
+    password_confirmation 'password'
+    sequence(:email) { |n| "user#{n}@example.com" }
+  end
+
+  factory :submission do
+    association :submitter, factory: :user
+  end
+end

--- a/spec/features/giving_feedback_spec.rb
+++ b/spec/features/giving_feedback_spec.rb
@@ -9,7 +9,7 @@ feature 'Providing feedback on submissions' do
   end
 
   let(:user) do
-    User.create! name: 'Test User', email: 'test@example.com', password: 'password'
+    create(:user, email: 'test@example.com', password: 'password')
   end
 
   let(:track) do

--- a/spec/features/registering_spec.rb
+++ b/spec/features/registering_spec.rb
@@ -7,9 +7,8 @@ feature 'Registering to attend' do
   end
 
   let(:submitter) do
-    User.create! name: 'Test User',
-                 email: 'test@example.com',
-                 password: 'password'
+    create(:user, email: 'test@example.com',
+                  password: 'password')
   end
 
   let(:track) do

--- a/spec/features/resetting_password_spec.rb
+++ b/spec/features/resetting_password_spec.rb
@@ -3,9 +3,8 @@ require 'spec_helper'
 feature 'Resetting my password' do
 
   scenario 'User goes through the password reset flow' do
-    User.create!(name: 'Forgetful User',
-                 email: 'test@example.com',
-                 password: 'password')
+    create(:user, email: 'test@example.com',
+                  password: 'password')
     visit '/'
     find('#menu-icon').click
     click_on 'Sign In'

--- a/spec/features/submitting_spec.rb
+++ b/spec/features/submitting_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature 'Creating a submission' do
 
   before do
-    @chair = User.create! name: 'Mr. Chairman', email: 'chair@example.com', password: 'passsword'
+    @chair = create(:user, name: 'Mr. Chairman', email: 'chair@example.com', password: 'passsword')
     @track = Track.new name: 'Bizness', is_submittable: true
     @track.chairs << @chair
     @track.save!
@@ -58,7 +58,7 @@ feature 'Creating a submission' do
   end
 
   scenario 'User tries to submit a new idea but fails to create an account' do
-    User.create! name: 'Here First', email: 'test@example.com', password: 'password', password_confirmation: 'password'
+    create(:user, name: 'Here First', email: 'test@example.com', password: 'password')
     visit '/panel-picker/mine'
     click_on 'Register for an account'
     fill_in 'Name', with: 'New Guy'

--- a/spec/features/volunteering_spec.rb
+++ b/spec/features/volunteering_spec.rb
@@ -9,7 +9,7 @@ feature 'Signing up to volunteer' do
   end
 
   let!(:user) do
-    User.create! name: 'Test User', email: 'test@example.com', password: 'password'
+    create(:user, email: 'test@example.com', password: 'password')
   end
 
   let!(:monday_shift) do

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -22,10 +22,9 @@ RSpec.describe Registration, type: :model do
 
   context 'subscribing to mailing lists' do
     let(:user) do
-      User.create! name: 'Test User',
-                   email: 'test@example.com',
-                   password: 'password',
-                   password_confirmation: 'password'
+      create(:user, name: 'Test User',
+                    email: 'test@example.com',
+                    password: 'password')
     end
 
     it 'subscribes automatically on creation' do

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,4 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+  config.before(:suite) { FactoryGirl.reload }
+end


### PR DESCRIPTION
- `submittedyears` and `confirmedyears` (Emma is goofy about assigned field names, sigh)
- Sync both the submitter e-mail and the contact e-mail
- Bring in FactoryGirl to start to simplify test setup

Fixes #41