### PR TITLE
Update after_sign_in_path to not reference cmsimple

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,7 +95,7 @@ class ApplicationController < ActionController::Base
     elsif user.is_admin?
       main_app.admin_root_path
     else
-      main_app.cmsimple_path
+      main_app.root_path
     end
   end
 end


### PR DESCRIPTION
This was causing issues with password reset, among other things.