### PR TITLE
Make sure paper_trail tracks the right user for changes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ require "application_responder"
 class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_paper_trail_whodunnit
 
   self.responder = ApplicationResponder
   respond_to :html


### PR DESCRIPTION
Previously it was hitting the `Unknown user` fallback all the time. According to [the docs](https://github.com/airblade/paper_trail/blob/master/doc/warning_about_not_setting_whodunnit.md) this filter is now necessary to add manually.