### PR TITLE
Get all current specs passing again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ group :test do
   gem 'email_spec', '~> 2.1.0'
   gem 'webmock'
   gem 'factory_girl_rails'
+  gem 'rspec-rails-time-metadata'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,8 @@ GEM
       sass (~> 3.4)
       thor (~> 0.19)
     builder (3.2.2)
-    capybara (2.4.1)
+    capybara (2.14.0)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -199,9 +200,8 @@ GEM
     multi_xml (0.5.5)
     navigasmic (1.1.0)
     newrelic_rpm (3.15.2.317)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     oauth (0.5.1)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
@@ -217,7 +217,6 @@ GEM
       activesupport (>= 3.0, < 6.0)
       request_store (~> 1.1)
     pg (0.15.1)
-    pkg-config (1.1.7)
     polyamorous (1.3.1)
       activerecord (>= 3.0)
     power_assert (0.2.2)
@@ -236,7 +235,7 @@ GEM
     puma (3.4.0)
     quiet_assets (1.0.2)
       railties (>= 3.1, < 5.0)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-canonical-host (0.0.8)
       addressable
       rack (~> 1.0)
@@ -286,6 +285,10 @@ GEM
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rinku (1.7.3)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
     rspec-core (3.2.3)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.1)
@@ -302,6 +305,9 @@ GEM
       rspec-expectations (~> 3.2.0)
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
+    rspec-rails-time-metadata (0.1.0)
+      activesupport (>= 4.1.0)
+      rspec (~> 3.0)
     rspec-support (3.2.2)
     ruby_parser (3.8.1)
       sexp_processor (~> 4.1)
@@ -432,6 +438,7 @@ DEPENDENCIES
   responders
   rinku
   rspec-rails
+  rspec-rails-time-metadata
   sanitize
   sass-rails
   selenium-webdriver

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -3,7 +3,7 @@ class SubmissionsController < ApplicationController
   respond_to  :html,
               :atom
   before_action :check_submissions_open, only: [ :new, :create ]
-  before_action :authenticate_user!, only: [ :new, :create, :mine ]
+  before_action :authenticate_user!, only: [ :new, :create, :mine, :submissions_closed ]
   before_action :check_feedback_open, only: [ :index ]
   before_action :set_submissions, only: [:edit, :update]
 

--- a/app/models/feature_toggler.rb
+++ b/app/models/feature_toggler.rb
@@ -2,7 +2,7 @@ class FeatureToggler
 
   include Redis::Objects
 
-  TOGGLES = %w(submission feedback registration volunteership).freeze
+  TOGGLES = %w(feedback registration volunteership).freeze
 
   TOGGLES.each do |toggle|
     value "#{toggle}_active", global: true, marshal: true

--- a/app/views/submissions/feedback_closed.html.slim
+++ b/app/views/submissions/feedback_closed.html.slim
@@ -1,5 +1,3 @@
-= render partial: 'nav', locals: { item: :mine }
-
 section.common.blue
   .section-content
     .dash-profile-bar

--- a/app/views/submissions/mine.html.slim
+++ b/app/views/submissions/mine.html.slim
@@ -39,7 +39,7 @@ section.common.sm-centered
         .talk-submission
           h6
             | #{submission.title} (#{submission.track.name})
-            - if submission.accepted? || submission.confirmed?
+            - if submission.created? || submission.open_for_voting? || submission.accepted? || submission.confirmed?
               = link_to 'Propose Update', edit_submission_path(submission), class: 'btn'
           /* a href='#' */
           /*   = render partial: 'icons/pencil' */

--- a/spec/features/resetting_password_spec.rb
+++ b/spec/features/resetting_password_spec.rb
@@ -7,7 +7,7 @@ feature 'Resetting my password' do
                   password: 'password')
     visit '/'
     find('#menu-icon').click
-    click_on 'Register / Sign In'
+    click_on 'Register'
     click_on 'Reset your password'
     fill_in 'E-mail Address', with: 'test@example.com'
     click_on 'Send reset instructions'

--- a/spec/features/simple_registering_spec.rb
+++ b/spec/features/simple_registering_spec.rb
@@ -6,7 +6,6 @@ feature 'Registering to attend (via kiosk)' do
     allow(ListSubscriptionJob).to receive(:perform_async)
     @track = Track.create! name: 'Bizness'
     FeatureToggler.activate_registration!
-    FeatureToggler.deactivate_submission!
     visit '/enable-simple-reg'
   end
 

--- a/spec/features/submitting_spec.rb
+++ b/spec/features/submitting_spec.rb
@@ -7,99 +7,117 @@ feature 'Creating a submission' do
     @track = Track.new name: 'Bizness', is_submittable: true
     @track.chairs << @chair
     @track.save!
-    FeatureToggler.activate_submission!
   end
 
-  scenario 'User submits a new idea' do
-    visit '/panel-picker/mine' # Can't click on the homepage for some reason
-    click_on 'Register for an account'
-    fill_in 'Name', with: 'New Guy'
-    fill_in 'E-mail Address', with: 'test@example.com'
-    fill_in 'Password', with: 'password', match: :prefer_exact
-    fill_in 'Confirm Password', with: 'password', match: :prefer_exact
+  describe 'when submissions are open' do
+    around(:each) do |example|
+      travel_to EventSchedule::SUBMISSION_OPEN_DATE + 1.day do
+        example.run
+      end
+    end
 
-    click_on 'Sign Up'
-    click_on 'Submit a New Proposal'
-    select 'Bizness', from: 'submission_track_id'
-    fill_in 'submission_title', with: 'Some talk'
-    fill_in 'submission_description', with: 'I am going to give a talk.'
-    fill_in 'submission_notes', with: 'Please pick my talk.'
-    fill_in 'submission_contact_email', with: 'test2@example.com'
-    click_button 'Submit'
-    expect(page).to have_content('Thanks!')
+    scenario 'User submits a new idea' do
+      visit '/panel-picker/mine' # Can't click on the homepage for some reason
+      click_on 'Register for an account'
+      fill_in 'Name', with: 'New Guy'
+      fill_in 'E-mail Address', with: 'test@example.com'
+      fill_in 'Password', with: 'password', match: :prefer_exact
+      fill_in 'Confirm Password', with: 'password', match: :prefer_exact
 
-    # See it in the list
-    expect(page).to have_content('Some talk (Bizness)')
+      click_on 'Sign Up'
+      click_on 'Submit a New Proposal'
+      select 'Bizness', from: 'submission_track_id'
+      fill_in 'submission_title', with: 'Some talk'
+      fill_in 'submission_description', with: 'I am going to give a talk.'
+      fill_in 'submission_target_audience_description', with: 'People who like talks.'
+      fill_in 'submission_notes', with: 'Please pick my talk.'
+      fill_in 'submission_contact_email', with: 'test2@example.com'
+      click_button 'Submit'
+      expect(page).to have_content('Thanks!')
 
-    # Confirmation to track chair
-    email = ActionMailer::Base.deliveries.detect { |e| e.to.include?('chair@example.com') }
-    expect(email.subject).to eq('A new DSW submission has been received for the Bizness track')
+      # See it in the list
+      expect(page).to have_content('Some talk (Bizness)')
 
-    # Confirmation to submitter
-    email = ActionMailer::Base.deliveries.detect { |e| e.to.include?('test2@example.com') }
-    expect(email.subject).to eq('Thanks for submitting a session proposal for Denver Startup Week!')
+      # Confirmation to track chair
+      email = ActionMailer::Base.deliveries.detect { |e| e.to.include?('chair@example.com') }
+      expect(email.subject).to eq('A new DSW submission has been received for the Bizness track')
+
+      # Confirmation to submitter
+      email = ActionMailer::Base.deliveries.detect { |e| e.to.include?('test2@example.com') }
+      expect(email.subject).to eq('Thanks for submitting a session proposal for Denver Startup Week!')
+    end
+
+    scenario 'User tries to submit a new idea but fails to create an account' do
+      create(:user, name: 'Here First', email: 'test@example.com', password: 'password')
+      visit '/panel-picker/mine'
+      click_on 'Register for an account'
+      fill_in 'Name', with: 'New Guy'
+      fill_in 'E-mail Address', with: 'test@example.com'
+      fill_in 'Password', with: 'password', match: :prefer_exact
+      fill_in 'Confirm Password', with: 'password', match: :prefer_exact
+      click_on 'Sign Up'
+      expect(page).to have_content('Email has already been taken')
+    end
+
+    scenario 'User edits an existing submission' do
+      visit '/panel-picker/mine' # Can't click on the homepage for some reason
+      click_on 'Register for an account'
+      fill_in 'Name', with: 'New Guy'
+      fill_in 'E-mail Address', with: 'test@example.com'
+      fill_in 'Password', with: 'password', match: :prefer_exact
+      fill_in 'Confirm Password', with: 'password', match: :prefer_exact
+
+      click_on 'Sign Up'
+      click_on 'Submit a New Proposal'
+      select 'Bizness', from: 'submission_track_id'
+      fill_in 'submission_title', with: 'Some talk'
+      fill_in 'submission_description', with: 'I am going to give a talk.'
+      fill_in 'submission_notes', with: 'Please pick my talk.'
+      fill_in 'submission_target_audience_description', with: 'People who like talks.'
+      fill_in 'submission_contact_email', with: 'test2@example.com'
+      click_button 'Submit'
+
+      click_on 'Propose Update'
+      fill_in 'submission_title', with: 'Updated talk'
+      fill_in 'submission_description', with: 'Here is my udpated idea'
+      fill_in 'submission_notes', with: 'I have even more things to say now.'
+      click_button 'Submit'
+
+      expect(page).to have_content 'Some talk'
+      expect(page).to have_content 'Your changes have been submitted'
+
+      Submission.last.promote_updates
+      visit page.current_path
+
+      expect(page).to have_content 'Updated talk'
+      expect(page).to_not have_content 'Some talk'
+    end
   end
 
-  scenario 'User tries to submit a new idea when submissions are closed' do
-    FeatureToggler.deactivate_submission!
-    visit '/panel-picker/submit'
-    expect(page).to have_content("Session submissions for #{Date.today.year} are currently closed")
-    expect(current_path).to eq('/panel-picker/submissions_closed')
+  describe 'when submissions are closed' do
+    around(:each) do |example|
+      travel_to EventSchedule::SUBMISSION_CLOSE_DATE + 1.day do
+        example.run
+      end
+    end
 
-    visit '/panel-picker/mine'
-    click_on 'Register for an account'
-    fill_in 'Name', with: 'New Guy'
-    fill_in 'E-mail Address', with: 'test@example.com'
-    fill_in 'Password', with: 'password', match: :prefer_exact
-    fill_in 'Confirm Password', with: 'password', match: :prefer_exact
+    scenario 'User tries to submit a new idea' do
+      visit '/panel-picker/mine'
 
-    click_on 'Sign Up'
-    expect(page).to have_no_link('Submit a New Proposal')
+      click_on 'Register for an account'
+      fill_in 'Name', with: 'New Guy'
+      fill_in 'E-mail Address', with: 'test@example.com'
+      fill_in 'Password', with: 'password', match: :prefer_exact
+      fill_in 'Confirm Password', with: 'password', match: :prefer_exact
+
+      click_on 'Sign Up'
+
+      expect(page).to have_no_link('Submit a New Proposal')
+
+      visit '/panel-picker/submit'
+
+      expect(page).to have_content("Session submissions for #{Date.today.year} are currently closed")
+      expect(current_path).to eq('/panel-picker/submissions_closed')
+    end
   end
-
-  scenario 'User tries to submit a new idea but fails to create an account' do
-    create(:user, name: 'Here First', email: 'test@example.com', password: 'password')
-    visit '/panel-picker/mine'
-    click_on 'Register for an account'
-    fill_in 'Name', with: 'New Guy'
-    fill_in 'E-mail Address', with: 'test@example.com'
-    fill_in 'Password', with: 'password', match: :prefer_exact
-    fill_in 'Confirm Password', with: 'password', match: :prefer_exact
-    click_on 'Sign Up'
-    expect(page).to have_content('Email has already been taken')
-  end
-
-  scenario 'User edits an existing submission' do
-    visit '/panel-picker/mine' # Can't click on the homepage for some reason
-    click_on 'Register for an account'
-    fill_in 'Name', with: 'New Guy'
-    fill_in 'E-mail Address', with: 'test@example.com'
-    fill_in 'Password', with: 'password', match: :prefer_exact
-    fill_in 'Confirm Password', with: 'password', match: :prefer_exact
-
-    click_on 'Sign Up'
-    click_on 'Submit a New Proposal'
-    select 'Bizness', from: 'submission_track_id'
-    fill_in 'submission_title', with: 'Some talk'
-    fill_in 'submission_description', with: 'I am going to give a talk.'
-    fill_in 'submission_notes', with: 'Please pick my talk.'
-    fill_in 'submission_contact_email', with: 'test2@example.com'
-    click_button 'Submit'
-
-    click_on 'Propose Update'
-    fill_in 'submission_title', with: 'Updated talk'
-    fill_in 'submission_description', with: 'Here is my udpated idea'
-    fill_in 'submission_notes', with: 'I have even more things to say now.'
-    click_button 'Submit'
-
-    expect(page).to have_content 'Some talk'
-    expect(page).to have_content 'Your changes have been submitted'
-
-    Submission.last.promote_updates
-    visit page.current_path
-
-    expect(page).to have_content 'Updated talk'
-    expect(page).to_not have_content 'Some talk'
-  end
-
 end

--- a/spec/models/feature_toggler_spec.rb
+++ b/spec/models/feature_toggler_spec.rb
@@ -23,23 +23,6 @@ describe FeatureToggler do
     end
   end
 
-  describe 'checking for the submission feature' do
-    it 'is inactive by default' do
-      expect(FeatureToggler.submission_active?).to be_falsy
-    end
-
-    it 'is active when it has been activated' do
-      FeatureToggler.activate_submission!
-      expect(FeatureToggler.submission_active?).to be_truthy
-    end
-
-    it 'is inactive when it has been deactivated' do
-      FeatureToggler.activate_submission!
-      FeatureToggler.deactivate_submission!
-      expect(FeatureToggler.submission_active?).to be_falsy
-    end
-  end
-
   describe 'checking for the registration feature' do
     it 'is inactive by default' do
       expect(FeatureToggler.registration_active?).to be_falsy


### PR DESCRIPTION
- Upgrade Capybara
- Bring in an Rspec time metadata helper
- Update fields and time stubbing for submission specs
- Guard submission closed dialog against unauthed users

Fixes https://github.com/denverstartupweek/dsw-site/issues/72