### PR TITLE
Fixed sampel database.yml filename in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -12,10 +12,10 @@ Dir.chdir APP_ROOT do
   system "gem install bundler --conservative"
   system "bundle check || bundle install"
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?("config/database.yml")
-  #   system "cp config/database.yml.sample config/database.yml"
-  # end
+  puts "\n== Copying sample files =="
+  unless File.exist?("config/database.yml")
+    system "cp config/database.example.yml config/database.yml"
+  end
 
   puts "\n== Preparing database =="
   system "bin/rake db:setup"


### PR DESCRIPTION
`bin/setup` failed to get my environment fully setup as this section of code was commented out. Fixing the name of the sample database.yml file fixed the issue though.