### PR TITLE
Make the submitter display properly in the update e-mail

### DIFF
--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -21,7 +21,7 @@ class NotificationsMailer < ActionMailer::Base
     @chair = chair
     @submission = submission
     @track = @submission.track
-    mail to: chair.email, subject: "#{@submission.submitter} has proposed an update needing your approval for the #{@track.name} track."
+    mail to: chair.email, subject: "#{@submission.submitter.name} has proposed an update needing your approval for the #{@track.name} track."
   end
 
   def confirm_new_submission(submission)


### PR DESCRIPTION
Previously it was outputting the user object, which wasn't very useful.