### PR TITLE
Convert homepage CTAs to be dynamic

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,3 +52,13 @@ Style/BracesAroundHashParameters:
     - context_dependent
 Layout/IndentHash:
   Enabled: false
+Metrics/BlockLength:
+  ExcludedMethods:
+    - context
+    - describe
+    - it
+    - shared_examples
+    - shared_examples_for
+    - namespace
+    - draw
+    - register

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'github-markdown'
 gem 'sanitize'
 gem 'rinku'
 gem 'gemoji'
+gem 'liquid'
 
 gem 'textacular'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    i18n (0.8.1)
+    i18n (0.8.6)
     icalendar (2.1.2)
     inherited_resources (1.7.2)
       actionpack (>= 3.2, < 5.2.x)
@@ -188,6 +188,7 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    liquid (4.0.0)
     lograge (0.2.0)
       actionpack
       activesupport
@@ -201,7 +202,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.2.0)
-    minitest (5.10.1)
+    minitest (5.10.2)
     multi_fetch_fragments (0.0.17)
     multi_xml (0.5.5)
     navigasmic (1.1.0)
@@ -241,7 +242,7 @@ GEM
     puma (3.4.0)
     quiet_assets (1.0.2)
       railties (>= 3.1, < 5.0)
-    rack (1.6.5)
+    rack (1.6.8)
     rack-canonical-host (0.0.8)
       addressable
       rack (~> 1.0)
@@ -334,7 +335,7 @@ GEM
       rubyzip (~> 1.0)
       websocket (~> 1.0)
     sexp_processor (4.9.0)
-    shoulda-matchers (3.1.1)
+    shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)
@@ -416,6 +417,7 @@ DEPENDENCIES
   icalendar
   jquery-rails
   kaminari
+  liquid
   lograge
   mail_view!
   memcachier

--- a/app/admin/homepage_ctas.rb
+++ b/app/admin/homepage_ctas.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 ActiveAdmin.register HomepageCta do
 
   menu label: 'Homepage Calls-to-Action'

--- a/app/admin/homepage_ctas.rb
+++ b/app/admin/homepage_ctas.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+#
+ActiveAdmin.register HomepageCta do
+
+  menu label: 'Homepage Calls-to-Action'
+
+  permit_params :title,
+                :subtitle,
+                :body,
+                :link_text,
+                :link_href,
+                :is_active
+
+  index do
+    selectable_column
+    column :title
+    column :subtitle
+    column :is_active
+    column :relevant_to_cycle
+    actions
+  end
+
+  filter :title
+
+  form do |f|
+    f.inputs do
+      f.input :title
+      f.input :subtitle
+      f.input :body
+      f.input :link_text
+      f.input :link_href
+      f.input :relevant_to_cycle,
+              label: 'Show during',
+              include_blank: 'All',
+              as: :select,
+              collection: EventSchedule::CYCLES.map { |c| [ c.to_s.titleize, c ] }
+      f.input :is_active
+    end
+
+    f.actions
+  end
+
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -87,11 +87,11 @@ class ApplicationController < ActionController::Base
       session[:previous_url]
     elsif user.registered?
       main_app.schedules_path
-    elsif FeatureToggler.registration_active?
+    elsif EventSchedule.registration_open?
       main_app.register_path
-    elsif EventSchedule.submissions_open?
+    elsif EventSchedule.cfp_open?
       main_app.new_submission_path
-    elsif EventSchedule.feedback_open?
+    elsif EventSchedule.voting_open?
       main_app.submissions_path
     elsif user.is_admin?
       main_app.admin_root_path

--- a/app/controllers/new_site_controller.rb
+++ b/app/controllers/new_site_controller.rb
@@ -3,6 +3,7 @@ class NewSiteController < ApplicationController
   before_filter :verify_page_exists!
 
   def index
+    @ctas = HomepageCta.active.relevant_to_cycles(EventSchedule.active_cycles).order('created_at DESC')
     render template: "new_site/#{params[:page].presence || 'index'}"
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -127,11 +127,11 @@ class SubmissionsController < ApplicationController
   end
 
   def check_submissions_open
-    redirect_to submissions_closed_submissions_path unless EventSchedule.submissions_open?
+    redirect_to submissions_closed_submissions_path unless EventSchedule.cfp_open?
   end
 
   def check_feedback_open
-    redirect_to feedback_closed_submissions_path unless EventSchedule.feedback_open?
+    redirect_to feedback_closed_submissions_path unless EventSchedule.voting_open?
   end
 
   def set_submissions

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,15 @@
 module ApplicationHelper
+
+  def process_with_liquid(content)
+    context = {
+      'submission_close_date' => EventSchedule::SUBMISSION_CLOSE_DATE,
+      'voting_close_date' => EventSchedule::VOTING_CLOSE_DATE,
+      'current_date' => DateTime.now
+    }
+    template = Liquid::Template.parse(content)
+    template.render(context)
+  end
+
   def process_with_pipeline(content)
     context = {
       asset_root: "/images/icons"

--- a/app/models/event_schedule.rb
+++ b/app/models/event_schedule.rb
@@ -1,28 +1,46 @@
 module EventSchedule
+
+  CYCLES = %w(cfp voting registration week).freeze
+
   SUBMISSION_OPEN_DATE = ActiveSupport::TimeZone['America/Denver'].parse('2017-03-19').freeze
   SUBMISSION_CLOSE_DATE = ActiveSupport::TimeZone['America/Denver'].parse('2017-04-21').freeze
 
   VOTING_OPEN_DATE = ActiveSupport::TimeZone['America/Denver'].parse('2017-05-10').freeze
   VOTING_CLOSE_DATE = ActiveSupport::TimeZone['America/Denver'].parse('2017-05-29').freeze
 
-  REGISTRATION_OPEN_DATE = ActiveSupport::TimeZone['America/Denver'].parse('2017-06-26').freeze
+  REGISTRATION_OPEN_DATE = ActiveSupport::TimeZone['America/Denver'].parse('2017-07-20').freeze
 
   WEEK_START_DATE = ActiveSupport::TimeZone['America/Denver'].parse('2017-09-25').freeze
   WEEK_END_DATE = ActiveSupport::TimeZone['America/Denver'].parse('2017-09-29').freeze
 
   class << self
-    def submissions_open?
+    def cfp_open?
       Time.zone.now > SUBMISSION_OPEN_DATE.at_beginning_of_day &&
         Time.zone.now < SUBMISSION_CLOSE_DATE.at_end_of_day
     end
 
-    def feedback_open?
+    def voting_open?
       Time.zone.now > VOTING_OPEN_DATE.at_beginning_of_day &&
         Time.zone.now < VOTING_CLOSE_DATE.at_end_of_day
     end
 
-    def week_started?
-      Time.zone.now > WEEK_START_DATE.at_beginning_of_day
+    def registration_open?
+      Time.zone.now > REGISTRATION_OPEN_DATE.at_beginning_of_day &&
+        Time.zone.now < WEEK_END_DATE.at_end_of_day
+    end
+
+    def in_week?
+      Time.zone.now > WEEK_START_DATE.at_beginning_of_day &&
+        Time.zone.now < WEEK_END_DATE.at_end_of_day
+    end
+
+    def active_cycles
+      cycles = []
+      cycles << :cfp if cfp_open?
+      cycles << :voting if voting_open?
+      cycles << :registration if registration_open?
+      cycles << :week if in_week?
+      cycles
     end
   end
 end

--- a/app/models/homepage_cta.rb
+++ b/app/models/homepage_cta.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class HomepageCta < ActiveRecord::Base
+
+  self.table_name = 'homepage_ctas'
+
+  validates :title,
+            :subtitle,
+            :body,
+            :link_text,
+            :link_href, presence: true
+
+  validates :title,
+            :subtitle,
+            :body, liquid: true
+
+  validates :relevant_to_cycle,
+            inclusion: { in: EventSchedule::CYCLES,
+                         allow_blank: true }
+
+  def self.active
+    where(is_active: true)
+  end
+
+  def self.relevant_to_cycles(cycles)
+    # TODO: Change this to a `.or` when we move to Rails 5
+    if cycles.any?
+      where('relevant_to_cycle IS NULL OR relevant_to_cycle IN (?)', cycles)
+    else
+      where('relevant_to_cycle IS NULL')
+    end
+  end
+end

--- a/app/validators/liquid_validator.rb
+++ b/app/validators/liquid_validator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class LiquidValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    Liquid::Template.parse(value)
+  rescue Liquid::SyntaxError
+    record.errors.add attribute, :liquid_syntax
+  end
+end

--- a/app/views/layouts/shared/_header.html.slim
+++ b/app/views/layouts/shared/_header.html.slim
@@ -14,7 +14,7 @@ header.masthead(data-bindable='toggle-nav')
       - if signed_in?
         div
           = link_to 'My Dashboard', mine_submissions_path
-      - elsif EventSchedule.submissions_open?
+      - elsif EventSchedule.cfp_open?
         div
           = link_to 'Submit Proposal', new_submission_path
       - elsif FeatureToggler.registration_active? && !registered?
@@ -23,7 +23,7 @@ header.masthead(data-bindable='toggle-nav')
       - else
         div
           = link_to 'Register / Sign In', mine_submissions_path
-      - if EventSchedule.feedback_open?
+      - if EventSchedule.voting_open?
         div
           = link_to 'Panel Picker', submissions_path
       div

--- a/app/views/new_site/index.html.slim
+++ b/app/views/new_site/index.html.slim
@@ -1,5 +1,5 @@
 section.hero
-  - unless EventSchedule.week_started?
+  - unless EventSchedule.in_week?
     h1.countdown #{time_remaining_to_deadline(EventSchedule::WEEK_START_DATE)}
   h2 September 25 - 29, 2017
   .section-content
@@ -7,41 +7,16 @@ section.hero
 
 section.hero-cta-4up
   section.hero-cta
-    - if EventSchedule.submissions_open?
-      article.teal
-        .section-content
-          h2 Call for Submissions
-          h3 Session submissions are open through #{EventSchedule::SUBMISSION_CLOSE_DATE.to_s(:month_day)}
-          h6 Denver Startup Week is powered by the community. Submit a topic for consideration for #{Date.today.year}.
-          = link_to 'Submit a Topic', mine_submissions_path, class: 'btn blue'
-    - elsif EventSchedule.feedback_open?
-      article.green
-        .section-content
-          h2 Voting is Open
-          h3 Cast your vote before #{EventSchedule::VOTING_CLOSE_DATE.to_s(:month_day)}
-          h6 The sessions are in, now we need you to help us finalize the best for this year's event. Don't delay, cast your vote and spread the word.
-          = link_to 'Vote Now', submissions_path, class: 'btn green'
-    - elsif FeatureToggler.registration_active? && !registered?
-      article.green
-        .section-content
-          h2 Registration is Open
-          h3 Register and build your schedule
-          h6 This year is going to be epic. We are excited to bring you the best of the best, and we couldn't have done this without you. Don't delay.
-          = link_to 'Register Now', new_registration_path, class: 'btn green'
-    - elsif FeatureToggler.registration_active? && registered?
-      article.green
-        .section-content
-          h2 Build Your Schedule
-          h3 Register and build your own schedule
-          h6 This year is going to be epic. We are excited to bring you the best of the best, and we couldn't have done this without you. Don't delay.
-          = link_to 'Build Your Schedule', schedules_path, class: 'btn green'
-    - else
-      article.green
-        .section-content
-          h2 Read our blog
-          h3 Stay up to date with DSW
-          h6 Our new blog features the latest updates on DSW and the Denver entrepreneurial community.
-          = link_to 'Visit the blog', 'https://medium.com/denver-startup-week', class: 'btn green'
+    - @ctas.each do |cta|
+      - cycle('teal', 'green', 'purple', 'blue', name: 'colors')
+      article(class="#{current_cycle('colors')}")
+        - cache(cta, current_cycle('colors')) do
+          .section-content
+            h2 = process_with_liquid cta.title
+            h3 = process_with_liquid cta.subtitle
+            h6 = process_with_liquid cta.body
+            = link_to cta.link_text, cta.link_href, class: "btn #{current_cycle('colors')}"
+
     article.purple
       .section-content
         h2 Get Involved

--- a/app/views/submissions/_nav.html.slim
+++ b/app/views/submissions/_nav.html.slim
@@ -2,7 +2,7 @@ nav
   .section-content
     h1 My Dashboard
     = link_to 'My Proposals', mine_submissions_path, class: item == :mine ? 'active' : ''
-    - if EventSchedule.submissions_open?
+    - if EventSchedule.cfp_open?
       = link_to 'Submit a Proposal', new_submission_path, class: item == :submit ? 'active' : ''
     = link_to 'FAQ', faq_submissions_path, class: item == :faq ? 'active' : ''
     = link_to 'Logout', destroy_user_session_path, method: :delete

--- a/app/views/submissions/_submission.html.haml
+++ b/app/views/submissions/_submission.html.haml
@@ -12,5 +12,5 @@
   %div.voting-cell(data-bindable="ajax-voter")
     %h4.voting-heading= submission.votes.size > 0 ? submission.votes.size : 'No votes yet'
     %div.voting-engine
-      - if EventSchedule.feedback_open? && signed_in?
+      - if EventSchedule.voting_open? && signed_in?
         = link_to '', submission_votes_path(submission), remote: true, method: :post, class: 'dswacon dswacon-vote-yes'

--- a/app/views/submissions/mine.html.slim
+++ b/app/views/submissions/mine.html.slim
@@ -46,7 +46,7 @@ section.common.sm-centered
     - else
       h6 You have not yet submitted any proposals for this year.
 
-- if EventSchedule.submissions_open?
+- if EventSchedule.cfp_open?
   section.common.sm-centered
     .section-content
       = link_to 'Submit a New Proposal', new_submission_path, class: 'btn primary'

--- a/config/initializers/liquid.rb
+++ b/config/initializers/liquid.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+if Rails.env.development? || Rails.env.test?
+  Liquid.cache_classes = false
+end
+
+# Blow up on template errors
+Liquid::Template.error_mode = :strict

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      messages:
+        liquid_syntax: "is not proper Liquid syntax"

--- a/db/migrate/20170718164505_create_homepage_ctas.rb
+++ b/db/migrate/20170718164505_create_homepage_ctas.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateHomepageCtas < ActiveRecord::Migration
+  def change
+    create_table :homepage_ctas do |t|
+      t.string :title, null: false
+      t.string :subtitle, null: false
+      t.string :body, null: false
+      t.string :link_text, null: false
+      t.string :link_href, null: false
+      t.string :relevant_to_cycle
+      t.boolean :is_active, default: true, null: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -143,3 +143,70 @@ end
   c.assign_attributes(attrs)
   c.save!
 end
+
+[
+  {
+    title: 'Call for Submissions',
+    subtitle: 'Session submissions are open through {{ submission_close_date | date: "%B %e" }}',
+
+    body: <<-EOF.strip_heredoc.squish,
+      Denver Startup Week is powered by the community.
+      Submit a topic for consideration for {{ current_date | date: "%Y" }}.
+    EOF
+    link_text: 'Submit a Topic',
+    link_href: '/panel-picker/mine',
+    relevant_to_cycle: 'cfp'
+  },
+  {
+    title: 'Voting is Open',
+    subtitle: 'Cast your vote by {{ voting_close_date | date: "%B %e" }}',
+    body: <<-EOF.strip_heredoc.squish,
+      The sessions are in, now we need you to help us finalize the best for this year's event.
+      Don't delay, cast your vote and spread the word.
+    EOF
+    link_text: 'Vote Now',
+    link_href: '/panel-picker',
+    relevant_to_cycle: 'voting'
+  },
+  {
+    title: 'Read our blog',
+    subtitle: 'Stay up to date with DSW',
+    body: 'Our new blog features the latest updates on DSW and the Denver entrepreneurial community.',
+    link_text: 'Visit the blog',
+    link_href: 'https://medium.com/denver-startup-week'
+  },
+  {
+    title: 'Registration is Open',
+    subtitle: 'Register & build your personalized {{ current_date | date: "%Y" }} schedule',
+    body: <<-EOF.strip_heredoc.squish,
+      This year is going to be epic. We are excited to bring you the best of the best,
+      and we couldn't have done this without you. Don't delay.
+    EOF
+    link_text: 'Check it out',
+    link_href: '/schedule',
+    relevant_to_cycle: 'registration'
+  },
+  {
+    title: 'Chase Basecamp',
+    subtitle: 'Immerse yourself in the heart of it all',
+    body: <<-EOF.strip_heredoc.squish,
+      Whether you want to find inspiration,
+      hone your business idea, or just refuel,
+      Basecamp powered by Chase is your home base!
+    EOF
+    link_text: 'Learn More',
+    link_href: '/basecamp',
+    relevant_to_cycle: 'week'
+  },
+  {
+    title: 'Get Involved',
+    subtitle: 'Be a part of something epic',
+    body: 'We are actively looking for sponsors and volunteers! Contact us now to learn more.',
+    link_text: 'Contact',
+    link_href: '/contact'
+  }
+].each do |attrs|
+  c = HomepageCta.where(title: attrs[:title]).first_or_initialize
+  c.assign_attributes(attrs)
+  c.save!
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -343,6 +343,43 @@ ALTER SEQUENCE general_inquiries_id_seq OWNED BY general_inquiries.id;
 
 
 --
+-- Name: homepage_ctas; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE homepage_ctas (
+    id integer NOT NULL,
+    title character varying NOT NULL,
+    subtitle character varying NOT NULL,
+    body character varying NOT NULL,
+    link_text character varying NOT NULL,
+    link_href character varying NOT NULL,
+    relevant_to_cycle character varying,
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: homepage_ctas_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE homepage_ctas_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: homepage_ctas_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE homepage_ctas_id_seq OWNED BY homepage_ctas.id;
+
+
+--
 -- Name: newsletter_signups; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -973,6 +1010,13 @@ ALTER TABLE ONLY general_inquiries ALTER COLUMN id SET DEFAULT nextval('general_
 
 
 --
+-- Name: homepage_ctas id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY homepage_ctas ALTER COLUMN id SET DEFAULT nextval('homepage_ctas_id_seq'::regclass);
+
+
+--
 -- Name: newsletter_signups id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1139,6 +1183,14 @@ ALTER TABLE ONLY comments
 
 ALTER TABLE ONLY general_inquiries
     ADD CONSTRAINT general_inquiries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: homepage_ctas homepage_ctas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY homepage_ctas
+    ADD CONSTRAINT homepage_ctas_pkey PRIMARY KEY (id);
 
 
 --
@@ -1688,4 +1740,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160912034451');
 INSERT INTO schema_migrations (version) VALUES ('20170320052451');
 
 INSERT INTO schema_migrations (version) VALUES ('20170713164355');
+
+INSERT INTO schema_migrations (version) VALUES ('20170718164505');
 

--- a/spec/models/homepage_cta_spec.rb
+++ b/spec/models/homepage_cta_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe HomepageCta, type: :model do
+  it { is_expected.to validate_presence_of(:title) }
+  it { is_expected.to validate_presence_of(:subtitle) }
+  it { is_expected.to validate_presence_of(:body) }
+  it { is_expected.to validate_presence_of(:link_text) }
+  it { is_expected.to validate_presence_of(:link_text) }
+  it { is_expected.to validate_inclusion_of(:relevant_to_cycle).in_array(EventSchedule::CYCLES) }
+
+  context 'Liquid syntax validation' do
+    it { is_expected.to allow_value('{{ current_date }}').for(:title) }
+    it { is_expected.not_to allow_value('{{ current_date').for(:title).with_message(:liquid_syntax) }
+    it { is_expected.to allow_value('{{ current_date }}').for(:subtitle) }
+    it { is_expected.not_to allow_value('{{ current_date').for(:subtitle).with_message(:liquid_syntax) }
+    it { is_expected.to allow_value('{{ current_date }}').for(:body) }
+    it { is_expected.not_to allow_value('{{ current_date').for(:body).with_message(:liquid_syntax) }
+  end
+end

--- a/spec/models/homepage_cta_spec.rb
+++ b/spec/models/homepage_cta_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe HomepageCta, type: :model do


### PR DESCRIPTION
- Bring in `liquid` to interpolate dynamic variables (though they get cached so we’ll need to be aware of dates)
- Convert a few more feature flags over to `EventSchedule`
- Add an admin UI
- Seed existing CTAs