### PR TITLE
Add a `Reply-To` header for general inquiries

### DIFF
--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -43,7 +43,9 @@ class NotificationsMailer < ActionMailer::Base
 
   def notify_of_new_inquiry(inquiry)
     @inquiry = inquiry
-    mail to: ENV['VOLUNTEER_SIGNUP_EMAIL_RECIPIENTS'].split(','), subject: 'Someone has inquired about DSW'
+    mail to: ENV['VOLUNTEER_SIGNUP_EMAIL_RECIPIENTS'].split(','),
+         subject: 'Someone has inquired about DSW',
+         reply_to: @inquiry.contact_email
   end
 
   def notify_of_new_sponsor_signup(sponsor_signup)

--- a/spec/features/contacting_spec.rb
+++ b/spec/features/contacting_spec.rb
@@ -23,8 +23,9 @@ feature 'Filling out the contact form' do
     expect(GeneralInquiry.last.notes).to eq('Nope')
 
     # Confirmation to volunteers box
-    email = ActionMailer::Base.deliveries.find { |e| e.to.include?('volunteer@example.com')}
-    expect(email.subject).to eq('Someone has inquired about DSW')
+    expect(last_email_sent).to have_subject('Someone has inquired about DSW')
+    expect(last_email_sent).to deliver_to('volunteer@example.com')
+    expect(last_email_sent).to reply_to('test@example.com')
   end
 
 end


### PR DESCRIPTION
Per [Helpscout’s docs](http://docs.helpscout.net/article/841-contact-forms) this should automatically get the conversations associated with the right customers.