### PR TITLE
Give admins the ability to send messages to session attendees

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'textacular'
 gem 'icalendar'
 
 gem 'premailer-rails'
+gem 'sendgrid'
 
 # State machines
 gem 'simple_states'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,6 +385,8 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    sendgrid (1.2.4)
+      json
     sexp_processor (4.10.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
@@ -490,6 +492,7 @@ DEPENDENCIES
   sass-rails
   select2-rails
   selenium-webdriver (~> 2.53)
+  sendgrid
   shoulda-matchers
   simple_form
   simple_states

--- a/app/admin/attendee_messages.rb
+++ b/app/admin/attendee_messages.rb
@@ -1,0 +1,53 @@
+ActiveAdmin.register AttendeeMessage do
+
+  menu parent: 'Sessions', priority: 3
+
+  permit_params :subject,
+                :body,
+                :submission_id
+
+  index do
+    selectable_column
+    column :subject
+    column :sent_status
+    actions
+  end
+
+  filter :subject
+  filter :body
+  filter :submission
+
+  action_item :deliver, only: %i(edit show) do
+    unless attendee_message.sent?
+      link_to 'Send',
+              deliver_admin_attendee_message_path(attendee_message),
+              method: :post
+    end
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :submission_id,
+              as: :select,
+              collection: Submission.for_current_year.for_schedule.order(:title),
+              include_blank: false
+      f.input :subject, hint: 'Must not exceed 100 characters'
+      f.input :body
+    end
+    f.actions
+  end
+
+  member_action :deliver, method: :post do
+    msg = AttendeeMessage.find(params[:id])
+    SendAttendeeMessageJob.perform_async(msg)
+    redirect_to admin_attendee_message_path(msg), notice: 'Send in progress!'
+  end
+
+  batch_action :deliver do |message_ids|
+    AttendeeMessage.find(message_ids).each do |msg|
+      SendAttendeeMessageJob.perform_async(msg)
+    end
+    redirect_to admin_attendee_messages_path
+  end
+
+end

--- a/app/admin/attendee_messages.rb
+++ b/app/admin/attendee_messages.rb
@@ -29,7 +29,10 @@ ActiveAdmin.register AttendeeMessage do
     f.inputs do
       f.input :submission_id,
               as: :select,
-              collection: Submission.for_current_year.for_schedule.order(:title),
+              collection: Submission.
+                          for_current_year.
+                          where(state: %w(confirmed venue_confirmed withdrawn)).
+                          order(:title),
               include_blank: false
       f.input :subject, hint: 'Must not exceed 100 characters'
       f.input :body

--- a/app/admin/attendee_messages.rb
+++ b/app/admin/attendee_messages.rb
@@ -1,13 +1,24 @@
 ActiveAdmin.register AttendeeMessage do
 
+  belongs_to :submission, optional: true
+
+  config.sort_order = 'created_at DESC'
+
   menu parent: 'Sessions', priority: 3
 
   permit_params :subject,
                 :body,
                 :submission_id
 
+  controller do
+    def scoped_collection
+      resource_class.includes(:submission)
+    end
+  end
+
   index do
     selectable_column
+    column :submission
     column :subject
     column :sent_status
     actions

--- a/app/admin/submissions.rb
+++ b/app/admin/submissions.rb
@@ -179,6 +179,11 @@ ActiveAdmin.register Submission do
     status_tag submission.state.to_s.titleize, status_for_submission(submission)
   end
 
+  sidebar 'Message', except: :index do
+    link_to "E-mail #{number_with_delimiter(submission.registrants.count)} attendees &rarr;".html_safe,
+            new_admin_submission_attendee_message_path(submission)
+  end
+
   sidebar :versionate, partial: 'admin/version', only: :show
 
   # Attendee export

--- a/app/jobs/send_attendee_message_job.rb
+++ b/app/jobs/send_attendee_message_job.rb
@@ -1,0 +1,13 @@
+class SendAttendeeMessageJob
+
+  include SuckerPunch::Job
+
+  def perform(attendee_message)
+    attendee_message.submission.registrants.find_in_batches(batch_size: 500) do |users|
+      with_retries(max_tries: 5) do
+        NotificationsMailer.send_attendee_message(attendee_message, users).deliver_now
+      end
+    end
+    attendee_message.update_column :sent_at, Time.zone.now
+  end
+end

--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -3,6 +3,8 @@ class NotificationsMailer < ActionMailer::Base
   include ScheduleHelper
   helper ScheduleHelper
 
+  include SendGrid
+
   default from: 'Denver Startup Week <info@denverstartupweek.org>'
 
   # Subject can be set in your I18n file at config/locales/en.yml
@@ -119,6 +121,13 @@ class NotificationsMailer < ActionMailer::Base
     @registration = registration
     @sessions = @registration.submissions.where(start_day: @day + 2).order('start_hour ASC')
     mail to: @registration.user.email, subject: "Your Denver Startup Week Daily Schedule for #{formatted_start_date_for_index(@day + 2, '%A %-m/%-d')}"
+  end
+
+  def send_attendee_message(message, users)
+    @message = message
+    sendgrid_recipients users.map(&:email)
+    mail to: 'info@denverstartupweek.org',
+         subject: "Regarding '#{message.submission.full_title}': #{message.subject}"
   end
 
 end

--- a/app/models/attendee_message.rb
+++ b/app/models/attendee_message.rb
@@ -12,7 +12,7 @@ class AttendeeMessage < ApplicationRecord
     if sent?
       "Sent at #{sent_at.to_s(:long)}"
     else
-      "Unsent"
+      'Unsent'
     end
   end
 end

--- a/app/models/attendee_message.rb
+++ b/app/models/attendee_message.rb
@@ -1,0 +1,18 @@
+class AttendeeMessage < ApplicationRecord
+  belongs_to :submission
+
+  validates :subject, presence: true, length: { maximum: 100 }
+  validates :body, presence: true
+
+  def sent?
+    sent_at.present?
+  end
+
+  def sent_status
+    if sent?
+      "Sent at #{sent_at.to_s(:long)}"
+    else
+      "Unsent"
+    end
+  end
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -48,6 +48,8 @@ class Submission < ApplicationRecord
                          source: :user
 
   has_many :sent_notifications, dependent: :destroy
+  has_many :attendee_messages, dependent: :restrict_with_error
+
   has_one :sponsorship, dependent: :restrict_with_error
 
   validates :title, presence: true

--- a/app/views/notifications_mailer/send_attendee_message.text.erb
+++ b/app/views/notifications_mailer/send_attendee_message.text.erb
@@ -1,0 +1,5 @@
+<%= @message.body %>
+
+----
+
+You are receiving this message because you added "<%= @message.submission.full_title %>" to your Denver Startup Week schedule. To adjust your preferences or opt out of future notifications for this session, please visit <%= schedule_url(@message.submission) %>.

--- a/db/migrate/20170908145727_create_attendee_messages.rb
+++ b/db/migrate/20170908145727_create_attendee_messages.rb
@@ -1,0 +1,12 @@
+class CreateAttendeeMessages < ActiveRecord::Migration[5.1]
+  def change
+    create_table :attendee_messages do |t|
+      t.string :subject, null: false
+      t.text :body, null: false
+      t.references :submission, foreign_key: true, null: false
+      t.datetime :sent_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -104,6 +104,40 @@ CREATE TABLE ar_internal_metadata (
 
 
 --
+-- Name: attendee_messages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE attendee_messages (
+    id bigint NOT NULL,
+    subject character varying NOT NULL,
+    body text NOT NULL,
+    submission_id bigint NOT NULL,
+    sent_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: attendee_messages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE attendee_messages_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: attendee_messages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE attendee_messages_id_seq OWNED BY attendee_messages.id;
+
+
+--
 -- Name: clusters; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -976,6 +1010,13 @@ ALTER TABLE ONLY active_admin_comments ALTER COLUMN id SET DEFAULT nextval('acti
 
 
 --
+-- Name: attendee_messages id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY attendee_messages ALTER COLUMN id SET DEFAULT nextval('attendee_messages_id_seq'::regclass);
+
+
+--
 -- Name: clusters id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1150,6 +1191,14 @@ ALTER TABLE ONLY active_admin_comments
 
 ALTER TABLE ONLY ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: attendee_messages attendee_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY attendee_messages
+    ADD CONSTRAINT attendee_messages_pkey PRIMARY KEY (id);
 
 
 --
@@ -1379,6 +1428,13 @@ CREATE INDEX index_admin_notes_on_resource_type_and_resource_id ON active_admin_
 
 
 --
+-- Name: index_attendee_messages_on_submission_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_attendee_messages_on_submission_id ON attendee_messages USING btree (submission_id);
+
+
+--
 -- Name: index_cmsimple_pages_on_parent_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1578,6 +1634,14 @@ ALTER TABLE ONLY volunteership_shifts
 
 
 --
+-- Name: attendee_messages fk_rails_555266c0e1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY attendee_messages
+    ADD CONSTRAINT fk_rails_555266c0e1 FOREIGN KEY (submission_id) REFERENCES submissions(id);
+
+
+--
 -- Name: volunteership_shifts fk_rails_8ff1f98788; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1698,6 +1762,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170822225752'),
 ('20170828185347'),
 ('20170830195828'),
-('20170906024523');
+('20170906024523'),
+('20170908145727');
 
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,7 +6,21 @@ FactoryGirl.define do
     sequence(:email) { |n| "user#{n}@example.com" }
   end
 
+  factory :registration do
+    association :user
+    age_range Registration::AGE_RANGES.first
+    primary_role 'Founder'
+  end
+
+  factory :track do
+    sequence(:name) { |n| "Track #{n}" }
+  end
+
   factory :submission do
+    sequence(:title) { |n| "Session #{n}" }
+    description 'I am a session'
+    contact_email 'test@example.com'
+    association :track
     association :submitter, factory: :user
   end
 
@@ -14,5 +28,11 @@ FactoryGirl.define do
     address '1060 W Addison St'
     city 'Chicago'
     state 'IL'
+  end
+
+  factory :attendee_message do
+    association :submission
+    subject 'Important'
+    body 'I am a message!'
   end
 end

--- a/spec/jobs/send_attendee_message_job_spec.rb
+++ b/spec/jobs/send_attendee_message_job_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe SendAttendeeMessageJob, job: true do
+  before do
+    allow(ListSubscriptionJob).to receive(:perform_async)
+  end
+
+  let(:msg) do
+    FactoryGirl.create(:attendee_message, subject: 'Important', body: 'Please read me')
+  end
+
+  let(:registration) do
+    FactoryGirl.create(:registration)
+  end
+
+  it 'sends a message' do
+    msg.submission.user_registrations << registration
+    SendAttendeeMessageJob.new.perform(msg)
+    expect(last_email_sent).to deliver_to('info@denverstartupweek.org')
+    expect(last_email_sent).to have_subject("Regarding '#{msg.submission.full_title}': Important")
+    expect(last_email_sent).to have_body_text(/Please read me/)
+    expect(last_email_sent).to have_header('X-SMTPAPI', "{\"to\": [\"#{registration.user.email}\"]}")
+  end
+end

--- a/spec/models/attendee_message_spec.rb
+++ b/spec/models/attendee_message_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe AttendeeMessage, type: :model do
     end
 
     it 'is "Sent at <time>" when sent_at is present' do
-      expect(AttendeeMessage.new(sent_at: DateTime.new(2017, 01, 02)).sent_status).to eq('Sent at January 02, 2017 00:00')
+      expect(AttendeeMessage.new(sent_at: DateTime.new(2017, 1, 2)).sent_status).
+        to eq('Sent at January 02, 2017 00:00')
     end
   end
 end

--- a/spec/models/attendee_message_spec.rb
+++ b/spec/models/attendee_message_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe AttendeeMessage, type: :model do
+  it { is_expected.to belong_to(:submission) }
+  it { is_expected.to validate_length_of(:subject).is_at_most(100) }
+  it { is_expected.to validate_presence_of(:body) }
+
+  describe 'sent status', freeze_time: true do
+    it 'is unsent when sent_at is nil' do
+      expect(AttendeeMessage.new.sent_status).to eq('Unsent')
+    end
+
+    it 'is "Sent at <time>" when sent_at is present' do
+      expect(AttendeeMessage.new(sent_at: DateTime.new(2017, 01, 02)).sent_status).to eq('Sent at January 02, 2017 00:00')
+    end
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Submission, type: :model do
   it { is_expected.to have_many(:session_registrations).dependent(:destroy) }
   it { is_expected.to have_many(:user_registrations) }
   it { is_expected.to have_many(:registrants) }
+  it { is_expected.to have_many(:sent_notifications).dependent(:destroy) }
+  it { is_expected.to have_many(:attendee_messages).dependent(:restrict_with_error) }
 
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_presence_of(:description) }


### PR DESCRIPTION
Based on Sendgrid’s SMTPAPI

- Create data model for attendee messages
- Create an admin for authoring/sending messages