### PR TITLE
Add link colors for headline and basecamp sessions to sponsor links

### DIFF
--- a/app/assets/stylesheets/redesign/views/sponsors.sass
+++ b/app/assets/stylesheets/redesign/views/sponsors.sass
@@ -49,29 +49,38 @@ section.common.sponsor
     margin-right: 10px
     vertical-align: -8px
   span, a
+    text-decoration: none
     text-transform: uppercase
     font-size: 20px
 .sponsor-track.green
-  .icon, span, a, a:active, a:visited, a:link, a:hover
+  .icon, span, a
     fill: $green-light
     color: $green-light
 .sponsor-track.teal
-  .icon, span, a, a:active, a:visited, a:link, a:hover
-    fill: $teal-light
+  .icon, span, a
     color: $teal-light
+    fill: $teal-light
 .sponsor-track.blue
-  .icon, span, a, a:active, a:visited, a:link, a:hover
+  .icon, span, a
     fill: $blue-light
     color: $blue-light
 .sponsor-track.purple
-  .icon, span, a, a:active, a:visited, a:link, a:hover
+  .icon, span, a
     fill: $purple-light
     color: $purple-light
 .sponsor-track.gold
-  .icon, span, a, a:active, a:visited, a:link, a:hover
+  .icon, span, a
     fill: $gold-light
     color: $gold-light
 .sponsor-track.orange
-  .icon, span, a, a:active, a:visited, a:link, a:hover
+  .icon, span, a
     fill: $orange-light
     color: $orange-light
+.sponsor-track.headline-session
+  .icon, span, a
+    fill: $headline-color-light
+    color: $headline-color-light
+.sponsor-track.basecamp-session
+  .icon, span, a
+    fill: $basecamp-color-light
+    color: $basecamp-color-light


### PR DESCRIPTION
They had been missing previously, causing those links to render in the underlying browser link colors.