### PR TITLE
Add a related sessions block to the detail view

### DIFF
--- a/app/assets/stylesheets/redesign/views/schedule-builder.sass
+++ b/app/assets/stylesheets/redesign/views/schedule-builder.sass
@@ -20,6 +20,8 @@
 .time-tag
   margin-bottom: 10px
 .scheduled-session
+  text-decoration: none
+  color: inherit
   display: flex
   margin-bottom: 5px
   .icon-container

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -44,6 +44,11 @@ class SchedulesController < ApplicationController
                order(:start_day).
                includes(:venue, :submitter, :track, :cluster, sponsorship: :track).
                first!
+
+    @related_sessions = @session.
+                        cached_similar_items.
+                        limit(3).
+                        includes(:venue, :track, :cluster, sponsorship: :track)
   end
 
   def feed

--- a/app/views/schedules/_scheduled_session.html.slim
+++ b/app/views/schedules/_scheduled_session.html.slim
@@ -1,0 +1,14 @@
+a.scheduled-session(href="#{schedule_path(submission)}")
+  div(class="icon-container #{submission.track.color}")
+    - if submission.track.icon
+      = render partial: "icons/#{submission.track.icon}"
+    - else
+      .icon
+  .session-info
+    .time-slot
+      .time #{local_assigns[:include_day] ? submission.human_short_start_day + ' ' : ''} #{submission.human_time_range}
+      - if submission.tags
+        .cluster-name = submission.tags
+    .title-venue
+      .session-title = submission.full_title
+      .session-location = submission.human_location_name

--- a/app/views/schedules/by_day.html.slim
+++ b/app/views/schedules/by_day.html.slim
@@ -41,20 +41,7 @@ section.common.sm-centered
     .time-block
       .time-tag = grouping.first.human_start_time
       - grouping.each do |submission|
-        .scheduled-session
-          div(class="icon-container #{submission.track.color}")
-            - if submission.track.icon
-              = render partial: "icons/#{submission.track.icon}"
-            - else
-              .icon
-          .session-info
-            .time-slot
-              .time = submission.human_time_range
-              - if submission.tags
-                .cluster-name = submission.tags
-            .title-venue
-              = link_to submission.full_title, schedule_path(submission), class: 'session-title'
-              .session-location = submission.human_location_name
+        = render partial: 'scheduled_session', locals: { submission: submission }
 
 - if registered? && params[:filter] == 'mine'
   section.common.sm-centered

--- a/app/views/schedules/show.html.slim
+++ b/app/views/schedules/show.html.slim
@@ -40,6 +40,14 @@ section.common
       div.confirmed-btn-container
         = link_to 'Remove from My Schedule', remove_from_schedule_path(@session), method: :delete, class: 'btn primary confirmed-btn'
 
+- if @related_sessions.any?
+  section.common
+    .section-content.sm-centered
+      h1 You may also be interested in
+      div
+        - @related_sessions.each do |submission|
+          = render partial: 'scheduled_session', locals: { submission: submission, include_day: true }
+
 section.common
   .section-content.sm-centered
     = link_to 'Back to Schedule', schedules_path, class: 'back-link'

--- a/db/migrate/20170918194840_enable_int_array_extension.rb
+++ b/db/migrate/20170918194840_enable_int_array_extension.rb
@@ -1,0 +1,5 @@
+class EnableIntArrayExtension < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'intarray'
+  end
+end

--- a/db/migrate/20170918201311_add_similar_ids_to_submissions.rb
+++ b/db/migrate/20170918201311_add_similar_ids_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddSimilarIdsToSubmissions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :submissions, :cached_similar_item_ids, :integer, array: true, default: []
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -744,7 +744,8 @@ CREATE TABLE submissions (
     proposed_updates json,
     open_to_collaborators boolean,
     from_underrepresented_group boolean,
-    target_audience_description text
+    target_audience_description text,
+    cached_similar_item_ids integer[] DEFAULT '{}'::integer[]
 );
 
 
@@ -1916,6 +1917,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170912152330'),
 ('20170912153018'),
 ('20170912155744'),
-('20170915145833');
+('20170915145833'),
+('20170918194840'),
+('20170918201311');
 
 

--- a/lib/tasks/recommendations.rake
+++ b/lib/tasks/recommendations.rake
@@ -1,0 +1,11 @@
+namespace :recommendations do
+  task refresh: :environment do
+    Submission.for_current_year.for_schedule.find_each do |s|
+      message = "Regenerated recommendations for #{s.id}: #{s.title}"
+      ms = Benchmark.ms do
+        s.refresh_similar_item_cache!
+      end
+      puts '%s (%.1fms)' % [ message, ms ]
+    end
+  end
+end


### PR DESCRIPTION
Based on https://github.com/geoffreylitt/simple_recommender with some customizations.

Needs a scheduled task set up to run `rake recommendations:refresh` periodically.

Also fix the longstanding annoyance where the whole schedule item wasn’t clickable.