### PR TITLE
Lock to a vendored Firefox if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ MK-TODO.md
 /public/packs
 /public/packs-test
 /node_modules
+vendor/firefox

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,6 +2,14 @@ require 'capybara/rails'
 require 'capybara/rspec'
 
 Capybara.default_driver = :selenium
+if ENV['FIREFOX_BIN_PATH']
+  puts "Using vendored Firefox binary from #{ENV['FIREFOX_BIN_PATH']}"
+  Capybara.register_driver :selenium do |app|
+    require 'selenium/webdriver'
+    Selenium::WebDriver::Firefox::Binary.path = ENV['FIREFOX_BIN_PATH']
+    Capybara::Selenium::Driver.new(app, browser: :firefox)
+  end
+end
 
 RSpec.configure do |config|
   config.prepend_before(:each, type: :feature) do


### PR DESCRIPTION
We're using 46 currently, which can be obtained from https://ftp.mozilla.org/pub/firefox/releases/46.0/mac/en-US/.

Move it to vendor/firefox/Firefox46.app and add this line to `.env`:

```
FIREFOX_BIN_PATH=vendor/firefox/Firefox46.app/Contents/MacOS/firefox-bin
```

Not needed on Travis as we lock the version there via `.travis.yml`.