### PR TITLE
Throttle e-mail subscription jobs to avoid rate limits at Emma/Sendgrid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'paper_trail'
 
 # Background processing
 gem 'sidekiq'
+gem 'sidekiq-throttled'
 
 group :development do
   gem 'listen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,6 +383,8 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.3, >= 3.3.3)
+    sidekiq-throttled (0.8.1)
+      sidekiq
     simple_states (1.0.0)
       activesupport
       hashr (~> 0.0.10)
@@ -490,6 +492,7 @@ DEPENDENCIES
   sendgrid-ruby
   shoulda-matchers
   sidekiq
+  sidekiq-throttled
   simple_states
   slim-rails
   textacular

--- a/app/jobs/list_subscription_job.rb
+++ b/app/jobs/list_subscription_job.rb
@@ -4,6 +4,11 @@ class ListSubscriptionJob
   SENDGRID_FIELDS = %i(first_name last_name).freeze
 
   include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
+  sidekiq_throttle(
+    concurrency: { limit: 10 },
+    threshold: { limit: 3, period: 2.seconds }
+  )
 
   def perform(email, extra_fields = {})
     subscribe_to_emma(email, extra_fields)


### PR DESCRIPTION
Using the `sidekiq-throttled` gem