### PR TITLE
Fix a major bug in the simple registration process

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -15,7 +15,7 @@ class RegistrationsController < ApplicationController
     if simple_registration?
       password = SecureRandom.hex
       @registration = Registration.new(registration_params)
-      @registration.user = User.first_or_initialize(email: registration_user_params[:email]) do |u|
+      @registration.user = User.where(email: registration_user_params[:email]).first_or_initialize do |u|
         u.assign_attributes(password: password,
                             password_confirmation: password,
                             name: registration_user_params[:name])

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -20,6 +20,8 @@ class Registration < ApplicationRecord
             :age_range,
             :primary_role, presence: true
 
+  validates :user_id, uniqueness: { scope: :year, message: 'may only register once per year' }
+
   after_initialize do
     self.year ||= Date.today.year
     self.calendar_token ||= SecureRandom.hex(25)

--- a/spec/features/simple_registering_spec.rb
+++ b/spec/features/simple_registering_spec.rb
@@ -34,6 +34,10 @@ feature 'Registering to attend (via kiosk)' do
     click_button 'Register'
     expect(page).to have_content('Thanks for registering')
     expect(current_path).to include('/schedule')
+    user = User.where(email: 'test2@example.com').first!
+    expect(user.name).to eq('Test Registrant')
+    expect(user.current_registration.company.name).to eq('Example.com')
+    expect(user.current_registration.primary_role).to eq('Developer')
   end
 
   scenario 'Registering to attend with a preexisting account' do
@@ -56,5 +60,7 @@ feature 'Registering to attend (via kiosk)' do
     expect(page).to have_content('Thanks for registering')
     expect(current_path).to include('/schedule')
     expect(user.reload.name).to eq('Preexisting Registrant')
+    expect(user.current_registration.company.name).to eq('Example.com')
+    expect(user.current_registration.primary_role).to eq('Developer')
   end
 end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe Registration, type: :model do
   it { is_expected.to validate_presence_of(:age_range) }
   it { is_expected.to validate_presence_of(:primary_role) }
 
+  describe 'with an existing registration' do
+    subject { create(:registration) }
+
+    it do
+      is_expected.to validate_uniqueness_of(:user_id).
+        scoped_to(:year).
+        with_message('may only register once per year')
+    end
+  end
+
   it 'defaults its year to the current year' do
     expect(Registration.new.year).to eq(Date.today.year)
   end


### PR DESCRIPTION
Users who completed that form were registered attached to the first user in the system, and their e-mails were not recorded.

This prevents that from recurring, adds additional tests, and a validation that ought to make it fail loudly if it recurs.