### PR TITLE
Change Liquid helpers to use dates in proper TZ

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,8 +2,8 @@ module ApplicationHelper
 
   def process_with_liquid(content)
     context = {
-      'submission_close_date' => AnnualSchedule.current.cfp_close_at,
-      'voting_close_date' => AnnualSchedule.current.voting_close_at,
+      'submission_close_date' => AnnualSchedule.current.cfp_close_at.in_time_zone(ActiveSupport::TimeZone['America/Denver']).at_end_of_day,
+      'voting_close_date' => AnnualSchedule.current.voting_close_at.in_time_zone(ActiveSupport::TimeZone['America/Denver']).at_end_of_day,
       'current_date' => DateTime.now
     }
     template = Liquid::Template.parse(content)


### PR DESCRIPTION
We should move this TZ conversion logic into the public interface for dates from AnnualSchedule at some point - it’s in there now but in private methods.

Tested locally and this fixes the off-by-one issue on those dates in CTAs.

/cc @marlabrizel