### PR TITLE
Filter schedule only on active clusters

### DIFF
--- a/app/views/schedules/by_day.html.slim
+++ b/app/views/schedules/by_day.html.slim
@@ -27,7 +27,7 @@ section.common.sm-centered
         - Track.in_display_order.each do |t|
           option(value="#{t.name}" selected=("selected" if params[:filter] == t.name)) #{t.name}#{t.is_submittable? ? ' Track' : '' }
       optgroup(label="View Sessions by Cluster")
-        - Cluster.all.each do |c|
+        - Cluster.active.each do |c|
           option(value="#{c.name}" selected=("selected" if params[:filter] == c.name)) #{c.name} Cluster
     select(name="year" value="#{params[:year]}" onchange="window.location.href = this.form.elements[2].value;")
       optgroup(label="View Sessions by Year")


### PR DESCRIPTION
Currently all clusters are available for filtering - this is confusing in the case that inactive clusters are a sort option because the sort won't yield results.

This will have the effect of making past schedules not searchable on inactive clusters, regardless of whether the cluster was active that year, since active/inactive is a binary value. IMO though, this is the lesser of two evils right now.