### PR TITLE
Implement dropdown for job-title in registration form closes #111

### DIFF
--- a/app/views/registrations/new.html.slim
+++ b/app/views/registrations/new.html.slim
@@ -38,7 +38,7 @@ section.common
       = f.text_field :company_name, data: { bindable: 'autocompleter', source: company_search_url }
 
       = f.label :primary_role, 'What is your job title?'
-      = f.text_field :primary_role, required: 'required'
+      = f.select :primary_role, collection: ['Accounting & Finance', 'Contract & Freelance', 'Customer Service/Success', 'Data/Analytics', 'Design', 'Developer/Engineer', 'Founder / Executive', 'Government', 'Health Care', 'Hospitality', 'Information Technology', 'Manufacturing', 'Non-profit', 'Operations', 'Product', 'Recruiting & Human Resources', 'Sales & Marketing', 'Writing & Content', 'Other'], required: 'required'
 
       = f.label :zip, 'What is the zip code of your primary residence?'
       = f.text_field :zip, required: 'required'
@@ -52,4 +52,4 @@ section.common
       = f.check_box :coc_acknowledgement, class: 'code-of-conduct', required: 'required'
       = render partial: 'layouts/shared/coc_acknowledgement'
 
-      = f.submit 'Register'
+      = f.submit 'Register' 

--- a/spec/features/simple_registering_spec.rb
+++ b/spec/features/simple_registering_spec.rb
@@ -29,7 +29,7 @@ feature 'Registering to attend (via kiosk)' do
     select '25-34 years old', from: 'registration_age_range'
     select 'Founder', from: 'registration_track_id'
     fill_in 'registration_company_name', with: 'Example.com'
-    fill_in 'registration_primary_role', with: 'Developer'
+    select 'Design', from: 'registration_primary_role'
     fill_in 'registration_zip', with: '12345'
     check 'registration_coc_acknowledgement'
     click_button 'Register'
@@ -38,7 +38,7 @@ feature 'Registering to attend (via kiosk)' do
     user = User.where(email: 'test2@example.com').first!
     expect(user.name).to eq('Test Registrant')
     expect(user.current_registration.company.name).to eq('Example.com')
-    expect(user.current_registration.primary_role).to eq('Developer')
+    expect(user.current_registration.primary_role).to eq('Design')
   end
 
   scenario 'Registering to attend with a preexisting account' do
@@ -55,7 +55,7 @@ feature 'Registering to attend (via kiosk)' do
     select '25-34 years old', from: 'registration_age_range'
     select 'Founder', from: 'registration_track_id'
     fill_in 'registration_company_name', with: 'Example.com'
-    fill_in 'registration_primary_role', with: 'Developer'
+    select 'Design', from: 'registration_primary_role'
     fill_in 'registration_zip', with: '12345'
     check 'registration_coc_acknowledgement'
     click_button 'Register'
@@ -63,6 +63,6 @@ feature 'Registering to attend (via kiosk)' do
     expect(current_path).to include('/schedule')
     expect(user.reload.name).to eq('Preexisting Registrant')
     expect(user.current_registration.company.name).to eq('Example.com')
-    expect(user.current_registration.primary_role).to eq('Developer')
+    expect(user.current_registration.primary_role).to eq('Design')
   end
 end


### PR DESCRIPTION
Closes #111 

We implemented a select (dropdown) in ```views/registrations/new.html.slim``` and changed tests in ```spec/features/simple_registering_spec.rb``` accordingly.  Failing tests in this suite are the result of missing content unrelated to this issue. 

![before](https://files.slack.com/files-pri/T029P2S9M-FCCH0FW5A/screen_shot_2018-08-21_at_4.40.40_pm.png)

![after](https://files.slack.com/files-pri/T029P2S9M-FCE4B912S/screen_shot_2018-08-21_at_4.43.36_pm.png)


* Co-authored-by: Spenser Leighton <spenser.leighton@gmail.com>
* Co-authored-by: Marika Ross <marika.ross@gmail.com>
* Co-authored-by: Austin Wiedenman <awiedenman@gmail.com>
 

