### PR TITLE
Only allow users to add sessions to their schedule that are in the current year

### DIFF
--- a/app/views/schedules/show.html.slim
+++ b/app/views/schedules/show.html.slim
@@ -51,7 +51,7 @@ section.common
       .location-details
         p = @session.human_location_name
 
-- if AnnualSchedule.registration_open?
+- if AnnualSchedule.registration_open? && @session.current_year?
   section.common
     .section-content.sm-centered
       - if !registered? || !registered_for_session?(@session)


### PR DESCRIPTION
We’ll need to purge and regenerate recommendations when this is done. Something like:

```
SessionRegistration.joins(:registration, :submission).where(registrations: { year: 2018 }).where.not(submissions: { year: 2018 }).find_each(&:destroy!)
```