### PR TITLE
Allow admins to view user’s schedules

### DIFF
--- a/app/admin/registration.rb
+++ b/app/admin/registration.rb
@@ -1,3 +1,22 @@
 ActiveAdmin.register Registration do
   belongs_to :user
+
+  show do
+    tabs do
+      tab :details do
+        attributes_table(*default_attribute_table_rows)
+      end
+
+      tab :schedule do
+        panel 'Schedule' do
+          table_for registration.submissions.includes(:sponsorship) do
+            column(:title, &:full_title)
+            column(:time) { |s| "#{s.human_start_day} #{s.human_time_range}".html_safe }
+            column(:location, &:human_location_name)
+            column { |s| link_to 'View on schedule', schedule_path(s) }
+          end
+        end
+      end
+    end
+  end
 end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -35,6 +35,7 @@ class Registration < ApplicationRecord
 
   belongs_to :user
   belongs_to :company, optional: true
+  belongs_to :track
   has_many :session_registrations, dependent: :destroy
   has_many :submissions, through: :session_registrations
   has_many :registration_attendee_goals, dependent: :destroy
@@ -55,7 +56,7 @@ class Registration < ApplicationRecord
   after_commit :subscribe_to_list
 
   def subscribe_to_list
-    registered_years = user.registrations.map(&:year).sort.map(&:to_s)
+    registered_years = user.registrations.reload.map(&:year).sort.map(&:to_s)
     ListSubscriptionJob.perform_async(user.email,
                                 registered_years: registered_years)
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -33,6 +33,7 @@ FactoryBot.define do
 
   factory :registration do
     association :user
+    association :track
     age_range { Registration::AGE_RANGES.first }
     primary_role { 'Founder' }
     coc_acknowledgement { true }

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -60,16 +60,20 @@ RSpec.describe Registration, type: :model do
     end
 
     it 'sends multiple registration years if applicable' do
-      user.registrations.create! contact_email: 'test@example.com',
-                                 year: 2015,
-                                 age_range: Registration::AGE_RANGES.first,
-                                 primary_role: 'Testing',
-                                 coc_acknowledgement: true
-      user.registrations.create! contact_email: 'test@example.com',
-                                 year: 2016,
-                                 age_range: Registration::AGE_RANGES.first,
-                                 primary_role: 'Testing',
-                                 coc_acknowledgement: true
+      create(:registration,
+             user: user,
+             contact_email: 'test@example.com',
+             year: 2015,
+             age_range: Registration::AGE_RANGES.first,
+             primary_role: 'Testing',
+             coc_acknowledgement: true)
+      create(:registration,
+             user: user,
+             contact_email: 'test@example.com',
+             year: 2016,
+             age_range: Registration::AGE_RANGES.first,
+             primary_role: 'Testing',
+             coc_acknowledgement: true)
       expect(ListSubscriptionJob).to have_received(:perform_async).with('test@example.com',
                                                                         registered_years: %w(2015 2016))
     end


### PR DESCRIPTION
Per @ryefinegan's request for looking up schedules to assist in scheduling interpreters, etc.