### PR TITLE
Switch submission registrant count to a cache

### DIFF
--- a/app/models/session_registration.rb
+++ b/app/models/session_registration.rb
@@ -1,4 +1,4 @@
 class SessionRegistration < ApplicationRecord
   belongs_to :registration
-  belongs_to :submission
+  belongs_to :submission, counter_cache: :registrant_count
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -272,7 +272,7 @@ class Submission < ApplicationRecord
   end
 
   def popular?
-    user_registrations.count * SHOW_RATE > (venue.try(:capacity) || Venue::DEFAULT_CAPACITY)
+    registrant_count * SHOW_RATE > (venue.try(:capacity) || Venue::DEFAULT_CAPACITY)
   end
 
   def venue_confirmed?

--- a/app/views/schedules/show.html.slim
+++ b/app/views/schedules/show.html.slim
@@ -31,7 +31,7 @@ section.common
         h6 = @session.tags
     .date #{@session.human_start_day} #{@session.start_datetime.strftime('%-m/%-d')}
     .time #{@session.human_time_range}
-    .attendee_count = "#{@session.registrants.count} attending"
+    .attendee_count = "#{@session.registrant_count} attending"
     .description = process_with_pipeline(@session.description)
 
     - if @session.live_stream_url.present?

--- a/db/migrate/20180924163222_add_registrant_count_to_submissions.rb
+++ b/db/migrate/20180924163222_add_registrant_count_to_submissions.rb
@@ -1,0 +1,9 @@
+class AddRegistrantCountToSubmissions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :submissions, :registrant_count, :integer, default: 0, null: false
+    Submission.reset_column_information
+    Submission.find_each do |s|
+      Submission.reset_counters s.id, :session_registrations
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -841,7 +841,8 @@ CREATE TABLE public.submissions (
     live_stream_url character varying,
     company_id bigint,
     coc_acknowledgement boolean DEFAULT false NOT NULL,
-    pitch_qualifying boolean DEFAULT false NOT NULL
+    pitch_qualifying boolean DEFAULT false NOT NULL,
+    registrant_count integer DEFAULT 0 NOT NULL
 );
 
 
@@ -2205,6 +2206,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180919041913'),
 ('20180919042513'),
 ('20180919050424'),
-('20180923214023');
+('20180923214023'),
+('20180924163222');
 
 


### PR DESCRIPTION
Should help speed up some requests. May be a little bit of a beast to deploy.