### PR TITLE
Remove unnecessary PaperTrail config

### DIFF
--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,1 +1,0 @@
-PaperTrail.config.track_associations = false


### PR DESCRIPTION
Per a helpful notification when booting the server:

> Association Tracking for PaperTrail has been extracted to a seperate gem. To use it, please add `paper_trail-association_tracking` to your Gemfile. If you don't use it (most people don't, that's the default) and you set `track_associations = false` somewhere (probably a rails initializer) you can remove that line now.


So, this PR does that - and deletes the initializer file for PaperTrail altogether since that was the only thing in there.