### PR TITLE
Adjust voting boxes to ellipse overflowing content

### DIFF
--- a/app/assets/stylesheets/redesign/views/vote.sass
+++ b/app/assets/stylesheets/redesign/views/vote.sass
@@ -182,12 +182,15 @@ form.filters
     font-family: 'Montserrat-Light'
     font-size: 14px
   .description
-    margin-bottom: 15px
-    max-height: 55px
-    overflow: hidden
     font-family: 'Montserrat-Light'
     font-size: 12px
     color: $copy-color-bold
+    margin-bottom: 15px
+    max-height: 11em
+    overflow: hidden
+    display: -webkit-box
+    -webkit-line-clamp: 2
+    -webkit-box-orient: vertical
   footer
     position: absolute
     display: flex


### PR DESCRIPTION
This is a little hacky but gets us there for now on Webkit-y browsers.

Before:

![Screen Shot 2019-05-07 at 5 57 07 PM](https://user-images.githubusercontent.com/22783/57340118-bce40480-70f1-11e9-9252-91de44916c95.png)

After:

![Screen Shot 2019-05-07 at 5 56 55 PM](https://user-images.githubusercontent.com/22783/57340124-c2414f00-70f1-11e9-92a6-02f23b4244a8.png)
