### PR TITLE
Adjust display of sign up / sign in link

### DIFF
--- a/app/views/layouts/shared/_header.html.slim
+++ b/app/views/layouts/shared/_header.html.slim
@@ -22,7 +22,7 @@ header.masthead.section__wrap(data-bindable='toggle-nav')
         - elsif AnnualSchedule.post_week?
           div.primary
             = link_to 'Schedule', schedules_path, class: %w(schedule users).include?(active_item) ? 'active' : ''
-        - else
+        - elsif !signed_in?
           div.primary
             = link_to 'Sign In/Sign Up', dashboard_path, class: active_item == 'users' ? 'active' : ''
         - if AnnualSchedule.voting_open?


### PR DESCRIPTION
No need to show it (ever) if you’re signed in.

Fixes https://github.com/denverstartupweek/dsw-site/issues/363