### PR TITLE
 Set up Rubocop to inherit from Standard config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+inherit_from:
+  - https://raw.githubusercontent.com/testdouble/standard/master/config/base.yml
 Style/ClassAndModuleChildren:
   Include:
     - lib/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,13 +62,7 @@ Style/FrozenStringLiteralComment:
 Layout/IndentHash:
   Enabled: false
 Metrics/BlockLength:
-  ExcludedMethods:
-    - context
-    - describe
-    - it
-    - shared_examples
-    - shared_examples_for
-    - namespace
-    - draw
-    - register
-    - feature
+  Exclude:
+    - Rakefile
+    - 'lib/tasks/**/*.rake'
+    - 'spec/**/*.rb'


### PR DESCRIPTION
This should normalize what rufo/standard apply in dev with with Hound checks in CI