### PR TITLE
Catch MissingTemplate error and re-raise for 404

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,20 +1,20 @@
 class SiteController < ApplicationController
-
   respond_to :html
+  rescue_from ActionView::MissingTemplate, with: :reraise_routing_error
 
   def index
-    ctas = HomepageCta.
-           active.
-           relevant_to_cycles(AnnualSchedule.active_cycles).
-           includes(:track).
-           in_priority_order
-    @two_up_ctas, @three_up_ctas = ctas.each_with_object([[], []]) do |cta, acc|
+    ctas = HomepageCta
+      .active
+      .relevant_to_cycles(AnnualSchedule.active_cycles)
+      .includes(:track)
+      .in_priority_order
+    @two_up_ctas, @three_up_ctas = ctas.each_with_object([[], []]) { |cta, acc|
       if cta.track.present?
         acc.second << cta
       else
         acc.first << cta
       end
-    end
+    }
 
     if @two_up_ctas.size == 3
       @three_up_ctas.unshift(@two_up_ctas.pop)
@@ -31,7 +31,11 @@ class SiteController < ApplicationController
   private
 
   def page_partial
-    template_name = "site/#{params[:page].presence || 'index'}".underscore
+    template_name = "site/#{params[:page].presence || "index"}".underscore
     lookup_context.find(template_name).virtual_path
+  end
+
+  def reraise_routing_error
+    raise ActionController::RoutingError.new("Template not found")
   end
 end


### PR DESCRIPTION
This should allow us to display Rails’ default 404 page instead of a 500.