### PR TITLE
Get involved

### DIFF
--- a/app/assets/stylesheets/redesign/layouts/secondary_hero.sass
+++ b/app/assets/stylesheets/redesign/layouts/secondary_hero.sass
@@ -29,7 +29,6 @@
   font-size: 120px
   line-height: 90px
   text-transform: uppercase
-  max-width: 697px
   margin-top: 108px
 
 .SecondaryHero-extras

--- a/app/assets/stylesheets/redesign/views/get_involved.sass
+++ b/app/assets/stylesheets/redesign/views/get_involved.sass
@@ -1,0 +1,3 @@
+.GetInvolved-list-wrapper
+  margin-top: -68px
+  margin-bottom: 40px

--- a/app/data/get_involved.yml
+++ b/app/data/get_involved.yml
@@ -1,0 +1,12 @@
+items:
+  - title: 'Present'
+    description: 
+      - 'The community plays a critical role in creating the event’s programming. Each spring, the community is asked to submit session ideas that they would like to put on during Denver Startup Week.' 
+      - 'Our call for presentations is currently closed. We hope that you will join us at some of the exciting sessions we have planned for this year!'
+    header_image: 'https://cdn-images-1.medium.com/max/800/1*amnvhplMQHkIrq_iYD8GUA.jpeg'
+    button_page_url: 'present'
+  - title: 'Content'
+    description: 
+      - 'Denver Startup Week is wholly financed through sponsorships that leverage the resources and capacities of the entire community – ultimately ensuring that Denver Startup Week exists for the community, by the community.'
+    header_image: 'https://cdn-images-1.medium.com/max/800/1*amnvhplMQHkIrq_iYD8GUA.jpeg'
+    button_page_url: 'content'

--- a/app/helpers/route_helper.rb
+++ b/app/helpers/route_helper.rb
@@ -110,20 +110,20 @@ module RouteHelper
     }
   end
 
-  def present_route 
+  def present_route
     {
       path: "/get-involved/present",
       label: "present"
     }
   end
 
-  def content_route 
+  def content_route
     {
       path: "/get-involved/content",
       label: "content"
     }
   end
-   
+
   def schedule_route
     {
       path: schedules_path,

--- a/app/helpers/route_helper.rb
+++ b/app/helpers/route_helper.rb
@@ -1,7 +1,7 @@
 module RouteHelper
 
   def main_menu
-    menu = [home_route, main_program_route, main_about_route, sponsors_route, get_involved_route, articles_route]
+    menu = [home_route, main_program_route, main_about_route, sponsors_route, main_get_involved_route, articles_route]
 
     if registration_open?
       menu.push schedule_route
@@ -29,6 +29,10 @@ module RouteHelper
 
   def about_routes
     [about_route, team_route, faq_route, assets_route]
+  end
+
+  def get_involved_routes
+    [get_involved_route, present_route, content_route]
   end
 
   def social_media_routes
@@ -63,13 +67,6 @@ module RouteHelper
     }
   end
 
-  def overview_route
-    {
-      path: "/about/overview",
-      label: "overview"
-    }
-  end
-
   def team_route
     {
       path: "/about/team",
@@ -98,13 +95,35 @@ module RouteHelper
     }
   end
 
-  def get_involved_route
+  def main_get_involved_route
     {
       path: "/get-involved",
-      label: "get involved"
+      label: "get involved",
+      nested_routes: get_involved_routes
     }
   end
 
+  def get_involved_route
+    {
+      path: "/get-involved",
+      label: "overview"
+    }
+  end
+
+  def present_route 
+    {
+      path: "/get-involved/present",
+      label: "present"
+    }
+  end
+
+  def content_route 
+    {
+      path: "/get-involved/content",
+      label: "content"
+    }
+  end
+   
   def schedule_route
     {
       path: schedules_path,

--- a/app/helpers/static_data_helper.rb
+++ b/app/helpers/static_data_helper.rb
@@ -24,4 +24,10 @@ module StaticDataHelper
       YAML.safe_load(File.read(File.expand_path("../data/about.yml",  __dir__)))
     ).deep_transform_keys(&:to_sym)
   end
+
+  def get_involved_static_data
+    HashWithIndifferentAccess.new(
+      YAML.safe_load(File.read(File.expand_path("../data/get_involved.yml",  __dir__)))
+    ).deep_transform_keys(&:to_sym)
+  end
 end

--- a/app/views/layouts/shared/_get_involved_secondary_hero_nav.html.slim
+++ b/app/views/layouts/shared/_get_involved_secondary_hero_nav.html.slim
@@ -1,0 +1,1 @@
+= render 'components/secondary_hero_nav', routes: get_involved_routes, nav_title: 'get involved'

--- a/app/views/site/get_involved.html.slim
+++ b/app/views/site/get_involved.html.slim
@@ -1,103 +1,112 @@
-= render partial: 'layouts/shared/get_involved_nav', locals: { item: :get_involved }
+= render layout: 'layouts/shared/secondary_hero', locals: { title: 'Get Involved', sub_title: 'By the community, for the community', description: 'Bringing Denver Startup Week to life takes the support, skills, and drive of an entire community: entrepreneurs, investors, civic leaders, educators, business pioneers, and more.' } do
+  = render 'layouts/shared/about_secondary_hero_nav'
 
-section.common.teal
-  .section-content.sm-centered
-    h1 By the community, for the community
-    h6 Bringing Denver Startup Week to life takes the support, skills, and drive of an entire community: entrepreneurs, investors, civic leaders, educators, business pioneers, and more.
-    h6 Want to get involved or support Denver Startup Week?  Here’s how to do it:
+div.About-list-wrapper
+  = render 'components/content_card_list', attributes: { 'aria-label': "About page" }  do
+    - about_static_data[:items].each do |card|
+      = render 'components/content_card_list_item' do
+        = render 'components/content_card', card: card, title: "#{card[:title]}", page_url: "about/#{card[:button_page_url]}"
 
-section.common
-  .section-content.sm-centered
-    h1 Present
-    h6 The community plays a critical role in creating the event’s programming. Each spring, the community is asked to submit session ideas that they would like to put on during Denver Startup Week.
+/ = render partial: 'layouts/shared/get_involved_nav', locals: { item: :get_involved }
 
-    - unless AnnualSchedule.cfp_open?
-      - if AnnualSchedule.post_week?
-        h6 Our call for presentations is currently closed. We anticipate reopening our CFP in the spring.
-      - else
-        h6 Our call for presentations is currently closed. We hope that you will join us at some of the exciting sessions we have planned for this year!
+/ section.common.teal
+/   .section-content.sm-centered
+/     h1 By the community, for the community
+/     h6 Bringing Denver Startup Week to life takes the support, skills, and drive of an entire community: entrepreneurs, investors, civic leaders, educators, business pioneers, and more.
+/     h6 Want to get involved or support Denver Startup Week?  Here’s how to do it:
 
-    = link_to 'Learn more', page_path(page: 'program/selection'), class: 'btn-cta'
+/ section.common
+/   .section-content.sm-centered
+/     h1 Present
+/     h6 The community plays a critical role in creating the event’s programming. Each spring, the community is asked to submit session ideas that they would like to put on during Denver Startup Week.
 
-section.common
-  .section-content.sm-centered
-    h1 Submit & Promote Content
-    h6 Denver Startup Week is by the community, for the community. That starts with you! We want you to share content that inspires, informs, and intrigues both Denver entrepreneurs and the global startup community.
-    h6 We are looking for blog submissions, free events to promote, instagram takeover stars-in-the-making, can’t-miss social media posts, and more! Have something to share with the Denver Startup Week audience that aligns with our spirit of free, educational, and inclusive? Then click below to learn more and submit!
-    = link_to 'Learn more', page_path(page: 'get-involved/content'), class: 'btn-cta'
+/     - unless AnnualSchedule.cfp_open?
+/       - if AnnualSchedule.post_week?
+/         h6 Our call for presentations is currently closed. We anticipate reopening our CFP in the spring.
+/       - else
+/         h6 Our call for presentations is currently closed. We hope that you will join us at some of the exciting sessions we have planned for this year!
 
-section.common
-  .section-content.sm-centered
-    h1 Volunteer
-    h6 Volunteers make up the vast majority of the Denver Startup Week organization and serve as the backbone of the event. From the Organizing Committee to our session attendants, Denver Startup Week would not be possible without the help and support of the entire community.
-    = link_to 'Learn more', 'https://www.cervistech.com/acts/console.php?console_id=0282&console_type=event&ht=1', target: '_blank', class: 'btn-cta'
+/     = link_to 'Learn more', page_path(page: 'program/selection'), class: 'btn-cta'
 
-section.common
-  .section-content.sm-centered
-    h1 Sponsor
-    h6 Denver Startup Week is wholly financed through sponsorships that leverage the resources and capacities of the entire community – ultimately ensuring that Denver Startup Week exists for the community, by the community.
-    = link_to 'Learn more', page_path(page: 'sponsors'), class: 'btn-cta'
+/ section.common
+/   .section-content.sm-centered
+/     h1 Submit & Promote Content
+/     h6 Denver Startup Week is by the community, for the community. That starts with you! We want you to share content that inspires, informs, and intrigues both Denver entrepreneurs and the global startup community.
+/     h6 We are looking for blog submissions, free events to promote, instagram takeover stars-in-the-making, can’t-miss social media posts, and more! Have something to share with the Denver Startup Week audience that aligns with our spirit of free, educational, and inclusive? Then click below to learn more and submit!
+/     = link_to 'Learn more', page_path(page: 'get-involved/content'), class: 'btn-cta'
 
-section.common
-  .section-content.sm-centered
-    h1 Host
-    h6 The events, sessions and other activities during Denver Startup Week are hosted in an array of venues around Downtown Denver.  A variety of venues are needed to accommodate the diverse selection of programs.
-    = link_to 'Learn more', '#contact-form', class: 'btn-cta'
+/ section.common
+/   .section-content.sm-centered
+/     h1 Volunteer
+/     h6 Volunteers make up the vast majority of the Denver Startup Week organization and serve as the backbone of the event. From the Organizing Committee to our session attendants, Denver Startup Week would not be possible without the help and support of the entire community.
+/     = link_to 'Learn more', 'https://www.cervistech.com/acts/console.php?console_id=0282&console_type=event&ht=1', target: '_blank', class: 'btn-cta'
 
-section.common
-  .section-content.sm-centered
-    h1 Job Fair & Showcase
-    h6 The Denver Startup Week Job Fair and Showcase is open to all companies with a priority given to Colorado-based startups and growth-stage companies, qualified non-profits, and training institutions. 
-    = link_to 'Learn more', '#contact-form', class: 'btn-cta'
+/ section.common
+/   .section-content.sm-centered
+/     h1 Sponsor
+/     h6 Denver Startup Week is wholly financed through sponsorships that leverage the resources and capacities of the entire community – ultimately ensuring that Denver Startup Week exists for the community, by the community.
+/     = link_to 'Learn more', page_path(page: 'sponsors'), class: 'btn-cta'
 
-section.common
-  .section-content.sm-centered
-    h1 Pitch Challenge
-    h6 The third annual Denver Startup Week Pitch Challenge will highlight and harness our city's entrepreneurial energy. This year’s challenge takes the typical pitch competition and spins it on its head, inviting the 15,000 attendees at DSW to cast their votes to determine the final six contenders.
-    h6 With a prize package valued at $100,000 in cash, services, and product, this pitch competition will showcase the best ideas and the brightest startups from Denver’s innovation community!
+/ section.common
+/   .section-content.sm-centered
+/     h1 Host
+/     h6 The events, sessions and other activities during Denver Startup Week are hosted in an array of venues around Downtown Denver.  A variety of venues are needed to accommodate the diverse selection of programs.
+/     = link_to 'Learn more', '#contact-form', class: 'btn-cta'
 
-    - close_dt = AnnualSchedule.current.pitch_application_close_at
-    - open_dt = AnnualSchedule.current.pitch_application_close_at
-    - if close_dt && open_dt && open_dt <= Date.today && close_dt >= Date.today
-      = link_to 'Learn more', '#contact-form', class: 'btn-cta'
-    - elsif close_dt && close_dt < Date.today
-      h6 Applications for this year's Pitch Challenge are now closed. We look forward to seeing you at the event!
-    - else
-      h6 More information  will be available later this summer.
+/ section.common
+/   .section-content.sm-centered
+/     h1 Job Fair & Showcase
+/     h6 The Denver Startup Week Job Fair and Showcase is open to all companies with a priority given to Colorado-based startups and growth-stage companies, qualified non-profits, and training institutions. 
+/     = link_to 'Learn more', '#contact-form', class: 'btn-cta'
 
-section.common
-  .section-content.sm-centered
-    h1 Startup Crawl
-    h6 The annual Startup Crawl features many of the hottest startup pads in Denver. Participants embark on a route throughout Downtown Denver, stopping at quintessential Denver startup offices to eat, drink, and celebrate our homegrown entrepreneurial culture. The crawl gives participants a chance to go behind the scenes and experience the company culture first hand.
+/ section.common
+/   .section-content.sm-centered
+/     h1 Pitch Challenge
+/     h6 The third annual Denver Startup Week Pitch Challenge will highlight and harness our city's entrepreneurial energy. This year’s challenge takes the typical pitch competition and spins it on its head, inviting the 15,000 attendees at DSW to cast their votes to determine the final six contenders.
+/     h6 With a prize package valued at $100,000 in cash, services, and product, this pitch competition will showcase the best ideas and the brightest startups from Denver’s innovation community!
 
-    = link_to 'Learn more', '#contact-form', class: 'btn-cta'
+/     - close_dt = AnnualSchedule.current.pitch_application_close_at
+/     - open_dt = AnnualSchedule.current.pitch_application_close_at
+/     - if close_dt && open_dt && open_dt <= Date.today && close_dt >= Date.today
+/       = link_to 'Learn more', '#contact-form', class: 'btn-cta'
+/     - elsif close_dt && close_dt < Date.today
+/       h6 Applications for this year's Pitch Challenge are now closed. We look forward to seeing you at the event!
+/     - else
+/       h6 More information  will be available later this summer.
 
-section.common
-  .section-content.sm-centered
-    h1 Mentorship
-    h6 Mentorship opportunities are offered at Basecamp throughout the week. Come connect with experienced mentors who can offer advice and support to launch you to the next level. Take advantage of individual, group, and online mentorship opportunities.
+/ section.common
+/   .section-content.sm-centered
+/     h1 Startup Crawl
+/     h6 The annual Startup Crawl features many of the hottest startup pads in Denver. Participants embark on a route throughout Downtown Denver, stopping at quintessential Denver startup offices to eat, drink, and celebrate our homegrown entrepreneurial culture. The crawl gives participants a chance to go behind the scenes and experience the company culture first hand.
 
-    = link_to 'Learn more', 'https://docs.google.com/forms/d/e/1FAIpQLScHAfkul7J8TATY2RuOOEa8_WmHJzMJH2M-u72kiYCZpn-sng/viewform', class: 'btn-cta'
+/     = link_to 'Learn more', '#contact-form', class: 'btn-cta'
 
-section.common#contact-form
-  .section-content.sm-centered
-    h1 Get Involved
-    h6 Please fill out as much information as you can. We'll be in touch shortly!
-    = form_for GeneralInquiry.new, html: { class: 'contact-us', data: { bindable: 'general-inquiry' } }, honeypot: true do |f|
-      = f.label :contact_name, 'Name'
-      = f.text_field :contact_name, required: 'required'
+/ section.common
+/   .section-content.sm-centered
+/     h1 Mentorship
+/     h6 Mentorship opportunities are offered at Basecamp throughout the week. Come connect with experienced mentors who can offer advice and support to launch you to the next level. Take advantage of individual, group, and online mentorship opportunities.
 
-      = f.label :company, 'Company or Organization (optional)'
-      = f.text_field :company
+/     = link_to 'Learn more', 'https://docs.google.com/forms/d/e/1FAIpQLScHAfkul7J8TATY2RuOOEa8_WmHJzMJH2M-u72kiYCZpn-sng/viewform', class: 'btn-cta'
 
-      = f.label :contact_email, 'E-mail Address'
-      = f.text_field :contact_email, required: 'required'
+/ section.common#contact-form
+/   .section-content.sm-centered
+/     h1 Get Involved
+/     h6 Please fill out as much information as you can. We'll be in touch shortly!
+/     = form_for GeneralInquiry.new, html: { class: 'contact-us', data: { bindable: 'general-inquiry' } }, honeypot: true do |f|
+/       = f.label :contact_name, 'Name'
+/       = f.text_field :contact_name, required: 'required'
 
-      = f.label :interest, 'What are you interested in?'
-      = f.select :interest, GeneralInquiry::INTERESTS.invert, required: 'required', include_blank: "I'm not sure"
+/       = f.label :company, 'Company or Organization (optional)'
+/       = f.text_field :company
 
-      = f.label :notes, 'Any additional notes?'
-      = f.text_field :notes, required: 'required'
+/       = f.label :contact_email, 'E-mail Address'
+/       = f.text_field :contact_email, required: 'required'
 
-      = f.submit 'Submit'
+/       = f.label :interest, 'What are you interested in?'
+/       = f.select :interest, GeneralInquiry::INTERESTS.invert, required: 'required', include_blank: "I'm not sure"
+
+/       = f.label :notes, 'Any additional notes?'
+/       = f.text_field :notes, required: 'required'
+
+/       = f.submit 'Submit'
 

--- a/app/views/site/get_involved.html.slim
+++ b/app/views/site/get_involved.html.slim
@@ -1,5 +1,5 @@
 = render layout: 'layouts/shared/secondary_hero', locals: { title: 'Get Involved', sub_title: 'By the community, for the community', description: 'Bringing Denver Startup Week to life takes the support, skills, and drive of an entire community: entrepreneurs, investors, civic leaders, educators, business pioneers, and more.' } do
-  = render 'layouts/shared/about_secondary_hero_nav'
+  = render 'layouts/shared/get_involved_secondary_hero_nav'
 
 div.About-list-wrapper
   = render 'components/content_card_list', attributes: { 'aria-label': "About page" }  do

--- a/app/views/site/get_involved.html.slim
+++ b/app/views/site/get_involved.html.slim
@@ -1,11 +1,11 @@
 = render layout: 'layouts/shared/secondary_hero', locals: { title: 'Get Involved', sub_title: 'By the community, for the community', description: 'Bringing Denver Startup Week to life takes the support, skills, and drive of an entire community: entrepreneurs, investors, civic leaders, educators, business pioneers, and more.' } do
   = render 'layouts/shared/get_involved_secondary_hero_nav'
 
-div.About-list-wrapper
-  = render 'components/content_card_list', attributes: { 'aria-label': "About page" }  do
-    - about_static_data[:items].each do |card|
+div.GetInvolved-list-wrapper
+  = render 'components/content_card_list', attributes: { 'aria-label': "Get involved page" }  do
+    - get_involved_static_data[:items].each do |card|
       = render 'components/content_card_list_item' do
-        = render 'components/content_card', card: card, title: "#{card[:title]}", page_url: "about/#{card[:button_page_url]}"
+        = render 'components/content_card', card: card, title: "#{card[:title]}", page_url: "get-involved/#{card[:button_page_url]}"
 
 / = render partial: 'layouts/shared/get_involved_nav', locals: { item: :get_involved }
 

--- a/app/views/site/get_involved/content.html.slim
+++ b/app/views/site/get_involved/content.html.slim
@@ -1,79 +1,84 @@
-= render partial: 'layouts/shared/get_involved_nav', locals: { item: :content }
-- content_for(:subtitle, 'Content')
+= render layout: 'layouts/shared/secondary_hero', locals: { title: 'Get Involved', sub_title: 'By the community, for the community', description: 'Bringing Denver Startup Week to life takes the support, skills, and drive of an entire community: entrepreneurs, investors, civic leaders, educators, business pioneers, and more.' } do
+  = render 'layouts/shared/get_involved_secondary_hero_nav'
 
-section.common.blue
-  .section-content.sm-centered
-    h1 Submit & Promote Content
-    h6 Denver Startup Week is by the community, for the community. We invite you to share content that inspires, informs, and intrigues both Denver entrepreneurs and the global startup community.
-    h6 We are looking for blog submissions, free events to promote, #MileHighHustle instagram takeovers, can’t-miss social media posts, and more! 
-    h6 Learn more about the various ways to submit and promote content through the Denver Startup Week channels.
-    h6 While we do our best to publish, highlight, and/or promote all of the submissions that we receive, we may not be able to accommodate all requests. Pitches for a specific company’s products or services will not be accepted. We appreciate your understanding.
+h1 Content Page
 
-section.common
-  .section-content.sm-centered
-    h1 Promote an Event
-    h6 Have an event that fits the Denver Startup Week spirit by being free, educational, and inclusive? We can publish the details in our email newsletter to spread the word to the DSW community.
-    h6 Here is what we will need from you:
-    ul
-      li
-        h6 Event Title, Date, Time, and Location
-      li
-        h6 Event Description (less than 100 words, written in the third person)
-      li
-        h6 Event Link
-    h6
-      em Please note: In most cases, we will only promote free events.
-    = link_to "Submit an event", "https://docs.google.com/forms/d/e/1FAIpQLScxgRj-lbkZRYD6iWBesI8ZIhFxLmdqjgDMBfzy26ovdy7t9Q/viewform", class: 'btn-cta'
+/ = render partial: 'layouts/shared/get_involved_nav', locals: { item: :content }
+/ - content_for(:subtitle, 'Content')
+
+/ section.common.blue
+/   .section-content.sm-centered
+/     h1 Submit & Promote Content
+/     h6 Denver Startup Week is by the community, for the community. We invite you to share content that inspires, informs, and intrigues both Denver entrepreneurs and the global startup community.
+/     h6 We are looking for blog submissions, free events to promote, #MileHighHustle instagram takeovers, can’t-miss social media posts, and more! 
+/     h6 Learn more about the various ways to submit and promote content through the Denver Startup Week channels.
+/     h6 While we do our best to publish, highlight, and/or promote all of the submissions that we receive, we may not be able to accommodate all requests. Pitches for a specific company’s products or services will not be accepted. We appreciate your understanding.
+
+/ section.common
+/   .section-content.sm-centered
+/     h1 Promote an Event
+/     h6 Have an event that fits the Denver Startup Week spirit by being free, educational, and inclusive? We can publish the details in our email newsletter to spread the word to the DSW community.
+/     h6 Here is what we will need from you:
+/     ul
+/       li
+/         h6 Event Title, Date, Time, and Location
+/       li
+/         h6 Event Description (less than 100 words, written in the third person)
+/       li
+/         h6 Event Link
+/     h6
+/       em Please note: In most cases, we will only promote free events.
+/     = link_to "Submit an event", "https://docs.google.com/forms/d/e/1FAIpQLScxgRj-lbkZRYD6iWBesI8ZIhFxLmdqjgDMBfzy26ovdy7t9Q/viewform", class: 'btn-cta'
 
 
-section.common
-  .section-content.sm-centered
-    h1 Social Media Promotion
-    h6 Hosting an event, celebrating a milestone, or posting an insightful video? Use #DENStartupWeek or mention us at @DENStartupWeek on any social media channel to contribute content to the online conversation. Or, send us the link to the post/tweet and we can do our best to share it!
-    = link_to "Retweet Me", "https://docs.google.com/forms/d/e/1FAIpQLSeJIA4hloOniZD-ZOjZW41D4WJUGxViQqfOdM_dKyw1iH8mmQ/viewform", class: 'btn-cta'
+/ section.common
+/   .section-content.sm-centered
+/     h1 Social Media Promotion
+/     h6 Hosting an event, celebrating a milestone, or posting an insightful video? Use #DENStartupWeek or mention us at @DENStartupWeek on any social media channel to contribute content to the online conversation. Or, send us the link to the post/tweet and we can do our best to share it!
+/     = link_to "Retweet Me", "https://docs.google.com/forms/d/e/1FAIpQLSeJIA4hloOniZD-ZOjZW41D4WJUGxViQqfOdM_dKyw1iH8mmQ/viewform", class: 'btn-cta'
 
-section.common
-  .section-content.sm-centered
-    h1 Blog Submission
-    h6 Our blog is an collection of unique insights, inspiring stories, thought leadership, founder profiles, can’t-miss news, and so much more.  Much like the event itself, the DSW Blog is by the community, for the community.
-    h6 Do you have an article that you would like featured on the blog? Or do you want to be published but don’t know where to start? Check out the ways to be a contributor to the blog below.
-    h4 Submit an Article
-    h6 Already have an article written or idea in mind? Check out the <a href="https://medium.com/@jayzes/submission-guidelines-85e45d333533">Denver Startup Week Blog Submission Guidelines</a> to see the guardrails for submitting your blog and getting it published.
-    h4 Use a DSW blog template
-    h6 Need a creative boost to start the writing process?  Here are a few blog ideas to get you started. Be sure to review the <a href="https://medium.com/@jayzes/submission-guidelines-85e45d333533">Denver Startup Week Blog Submission Guidelines</a> early in the writing process. Once your article is ready for the limelight, follow our submission instructions and start promoting your article!
-    h6 Blog Idea #1: Tell Us Your Denver Startup Week Success Story
-    h6 Denver Startup Week is a crazy five days. Companies are founded, hires are made, new clients are found - there is too much good for us to keep straight. We’d love to hear your Denver Startup Week success story and how it has propelled you forward. It doesn’t all have to be sunshine and smiles - we’d love to hear any Denver Startup Week challenges that you’ve faced and how you have overcome adversity around the week, as well. 
-    h6 Blog Idea #2: Share Your Mile High Hustle
-    h6 Tell us your startup story… the good, the bad, the ugly. This is your chance to play the part of the interviewee on How I Built This. Readers should feel like they know you better as well as learned from your accomplishments and mistakes.
-    h6 Blog Idea #3: Make a Denver Startup Week Guide
-    h6 Denver Startup Week can be overwhelming and with hundreds of events, it can be hard to know where to begin, what to attend, and how to crush the week. Want to position yourself as a guru in your field? Have some tips & tricks to share for networking at sessions? Make a DSW Guide! This is your chance to be Rick Steves. Check out past examples <a href="https://www.cuttlesoft.com/denver-startup-week-2018-survival-guide/">here</a>, <a href="https://www.westword.com/news/guide-to-denver-startup-week-10824655">here</a>, <a href="https://medium.com/denver-startup-week/5-ways-to-make-the-most-of-denver-startup-week-2018-eb0a86ad752">here</a>, and <a href="https://blogs.perficient.com/2018/09/06/perficients-guide-denver-startup-week-2018/">here</a> and get creative!
-    = link_to "Submit a blog article", "https://docs.google.com/forms/d/e/1FAIpQLSfGSH_VNpSWS0nFEYu03zFXiZk_UZpZSSwid6-uJJBveO7DAg/viewform", class: 'btn-cta'
+/ section.common
+/   .section-content.sm-centered
+/     h1 Blog Submission
+/     h6 Our blog is an collection of unique insights, inspiring stories, thought leadership, founder profiles, can’t-miss news, and so much more.  Much like the event itself, the DSW Blog is by the community, for the community.
+/     h6 Do you have an article that you would like featured on the blog? Or do you want to be published but don’t know where to start? Check out the ways to be a contributor to the blog below.
+/     h4 Submit an Article
+/     h6 Already have an article written or idea in mind? Check out the <a href="https://medium.com/@jayzes/submission-guidelines-85e45d333533">Denver Startup Week Blog Submission Guidelines</a> to see the guardrails for submitting your blog and getting it published.
+/     h4 Use a DSW blog template
+/     h6 Need a creative boost to start the writing process?  Here are a few blog ideas to get you started. Be sure to review the <a href="https://medium.com/@jayzes/submission-guidelines-85e45d333533">Denver Startup Week Blog Submission Guidelines</a> early in the writing process. Once your article is ready for the limelight, follow our submission instructions and start promoting your article!
+/     h6 Blog Idea #1: Tell Us Your Denver Startup Week Success Story
+/     h6 Denver Startup Week is a crazy five days. Companies are founded, hires are made, new clients are found - there is too much good for us to keep straight. We’d love to hear your Denver Startup Week success story and how it has propelled you forward. It doesn’t all have to be sunshine and smiles - we’d love to hear any Denver Startup Week challenges that you’ve faced and how you have overcome adversity around the week, as well. 
+/     h6 Blog Idea #2: Share Your Mile High Hustle
+/     h6 Tell us your startup story… the good, the bad, the ugly. This is your chance to play the part of the interviewee on How I Built This. Readers should feel like they know you better as well as learned from your accomplishments and mistakes.
+/     h6 Blog Idea #3: Make a Denver Startup Week Guide
+/     h6 Denver Startup Week can be overwhelming and with hundreds of events, it can be hard to know where to begin, what to attend, and how to crush the week. Want to position yourself as a guru in your field? Have some tips & tricks to share for networking at sessions? Make a DSW Guide! This is your chance to be Rick Steves. Check out past examples <a href="https://www.cuttlesoft.com/denver-startup-week-2018-survival-guide/">here</a>, <a href="https://www.westword.com/news/guide-to-denver-startup-week-10824655">here</a>, <a href="https://medium.com/denver-startup-week/5-ways-to-make-the-most-of-denver-startup-week-2018-eb0a86ad752">here</a>, and <a href="https://blogs.perficient.com/2018/09/06/perficients-guide-denver-startup-week-2018/">here</a> and get creative!
+/     = link_to "Submit a blog article", "https://docs.google.com/forms/d/e/1FAIpQLSfGSH_VNpSWS0nFEYu03zFXiZk_UZpZSSwid6-uJJBveO7DAg/viewform", class: 'btn-cta'
 
-section.common
-  .section-content.sm-centered
-    h1 Instagram Takeover
-    h6 DSW’s <a href="https://www.instagram.com/denstartupweek/">Instagram account</a> highlights the people, places, and energy of Denver’s entrepreneurial community. As we look to highlight the best of our city, we want you to show us a day-in-your-hustle!
-    h6 Come take over our Instagram account for a day, show us your <a href="https://www.instagram.com/denstartupweek/">#MileHighHustle</a>, and highlight the amazing work that you do for the Denver Startup Week community.
-    h6 Here is what we will need from you: 
-    ul
-      li
-        h6 Your Name, Company, and Location
-      li
-        h6 Short description of who you are, what you do, and why you are a compelling person to take over the DSW Instagram (less than 250 words)
-      li
-        h6 Link to your social media profiles: Instagram, LinkedIn, Twitter, etc. (as is applicable)
-    = link_to "Apply for an Insta takeover", "mailto:info@denverstartupweek.org?subject=Instagram Takeover", class: 'btn-cta'
+/ section.common
+/   .section-content.sm-centered
+/     h1 Instagram Takeover
+/     h6 DSW’s <a href="https://www.instagram.com/denstartupweek/">Instagram account</a> highlights the people, places, and energy of Denver’s entrepreneurial community. As we look to highlight the best of our city, we want you to show us a day-in-your-hustle!
+/     h6 Come take over our Instagram account for a day, show us your <a href="https://www.instagram.com/denstartupweek/">#MileHighHustle</a>, and highlight the amazing work that you do for the Denver Startup Week community.
+/     h6 Here is what we will need from you: 
+/     ul
+/       li
+/         h6 Your Name, Company, and Location
+/       li
+/         h6 Short description of who you are, what you do, and why you are a compelling person to take over the DSW Instagram (less than 250 words)
+/       li
+/         h6 Link to your social media profiles: Instagram, LinkedIn, Twitter, etc. (as is applicable)
+/     = link_to "Apply for an Insta takeover", "mailto:info@denverstartupweek.org?subject=Instagram Takeover", class: 'btn-cta'
 
-section.common
-  .section-content.sm-centered
-    h1 Special Announcements
-    h6 Have something extra special that you want to share with the Denver Startup Week community? Let us know! This can include big awards that your company wins, major funding rounds, can’t-miss happenings or stories - or something else that you can’t help but want to share with the DSW community. We will do our best to pass along the exciting news. 
-    h6 Here is what we will need from you:
-    ul
-      li
-        h6 Special Announcement "Title"
-      li
-        h6 Description and overview as to what this special happening is and why it matters to the Denver Startup Week community (less than 300 words)
-      li
-        h6 Any pertinent links
-    = link_to "Submit a Special Announcement", "https://docs.google.com/forms/d/e/1FAIpQLSdKJ2pY-Qjt-yjQO78NGQmfD-9kxS8P-q4NQOPXwax5Zbe1QQ/viewform", class: 'btn-cta'
+/ section.common
+/   .section-content.sm-centered
+/     h1 Special Announcements
+/     h6 Have something extra special that you want to share with the Denver Startup Week community? Let us know! This can include big awards that your company wins, major funding rounds, can’t-miss happenings or stories - or something else that you can’t help but want to share with the DSW community. We will do our best to pass along the exciting news. 
+/     h6 Here is what we will need from you:
+/     ul
+/       li
+/         h6 Special Announcement "Title"
+/       li
+/         h6 Description and overview as to what this special happening is and why it matters to the Denver Startup Week community (less than 300 words)
+/       li
+/         h6 Any pertinent links
+/     = link_to "Submit a Special Announcement", "https://docs.google.com/forms/d/e/1FAIpQLSdKJ2pY-Qjt-yjQO78NGQmfD-9kxS8P-q4NQOPXwax5Zbe1QQ/viewform", class: 'btn-cta'

--- a/app/views/site/get_involved/present.html.slim
+++ b/app/views/site/get_involved/present.html.slim
@@ -1,0 +1,4 @@
+= render layout: 'layouts/shared/secondary_hero', locals: { title: 'Get Involved', sub_title: 'By the community, for the community', description: 'Bringing Denver Startup Week to life takes the support, skills, and drive of an entire community: entrepreneurs, investors, civic leaders, educators, business pioneers, and more.' } do
+  = render 'layouts/shared/get_involved_secondary_hero_nav'
+
+h1 Present Page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   # Redirects for old paths
   get "/contact/press", to: redirect("/press")
   get "/contact/assets", to: redirect("/assets")
-  get "/faq", to: redirect("/get-involved/faq")
+  get "/faq", to: redirect("/about/faq")
   get "/contact", to: redirect("/get-involved")
 
   get "/resources", to: redirect("/program")

--- a/spec/features/contacting_spec.rb
+++ b/spec/features/contacting_spec.rb
@@ -1,33 +1,33 @@
-require 'spec_helper'
+# require 'spec_helper'
 
-feature 'Filling out the contact form' do
+# feature 'Filling out the contact form' do
 
-  before do
-    ENV['VOLUNTEER_SIGNUP_EMAIL_RECIPIENTS'] = 'volunteer@example.com'
-  end
+#   before do
+#     ENV['VOLUNTEER_SIGNUP_EMAIL_RECIPIENTS'] = 'volunteer@example.com'
+#   end
 
-  scenario 'User submits a contact request' do
-    visit '/get-involved' # Can't click on the element for some reason
-    fill_in 'Name', with: 'Some person'
-    fill_in 'Company or Organization (optional)', with: 'Acme Corp'
-    fill_in 'E-mail Address', with: 'test@example.com'
-    select 'Sponsorship', from: 'What are you interested in?'
-    fill_in 'Any additional notes?', with: 'Nope'
-    click_button 'Submit'
-    expect(page).to have_button('Thanks! We will be in touch shortly', disabled: true)
+#   scenario 'User submits a contact request' do
+#     visit '/get-involved' # Can't click on the element for some reason
+#     fill_in 'Name', with: 'Some person'
+#     fill_in 'Company or Organization (optional)', with: 'Acme Corp'
+#     fill_in 'E-mail Address', with: 'test@example.com'
+#     select 'Sponsorship', from: 'What are you interested in?'
+#     fill_in 'Any additional notes?', with: 'Nope'
+#     click_button 'Submit'
+#     expect(page).to have_button('Thanks! We will be in touch shortly', disabled: true)
 
-    # Saved to DB
-    expect(GeneralInquiry.count).to eq(1)
-    expect(GeneralInquiry.last.contact_email).to eq('test@example.com')
-    expect(GeneralInquiry.last.contact_name).to eq('Some person')
-    expect(GeneralInquiry.last.company).to eq('Acme Corp')
-    expect(GeneralInquiry.last.interest).to eq('sponsorship')
-    expect(GeneralInquiry.last.notes).to eq('Nope')
+#     # Saved to DB
+#     expect(GeneralInquiry.count).to eq(1)
+#     expect(GeneralInquiry.last.contact_email).to eq('test@example.com')
+#     expect(GeneralInquiry.last.contact_name).to eq('Some person')
+#     expect(GeneralInquiry.last.company).to eq('Acme Corp')
+#     expect(GeneralInquiry.last.interest).to eq('sponsorship')
+#     expect(GeneralInquiry.last.notes).to eq('Nope')
 
-    # Confirmation to volunteers box
-    expect(last_email_sent).to have_subject('Someone has inquired about DSW')
-    expect(last_email_sent).to deliver_to('volunteer@example.com')
-    expect(last_email_sent).to reply_to('test@example.com')
-  end
+#     # Confirmation to volunteers box
+#     expect(last_email_sent).to have_subject('Someone has inquired about DSW')
+#     expect(last_email_sent).to deliver_to('volunteer@example.com')
+#     expect(last_email_sent).to reply_to('test@example.com')
+#   end
 
-end
+# end

--- a/spec/features/contacting_spec.rb
+++ b/spec/features/contacting_spec.rb
@@ -7,6 +7,7 @@ feature 'Filling out the contact form' do
   end
 
   scenario 'User submits a contact request' do
+    pending('refactor')
     visit '/get-involved' # Can't click on the element for some reason
     fill_in 'Name', with: 'Some person'
     fill_in 'Company or Organization (optional)', with: 'Acme Corp'

--- a/spec/features/contacting_spec.rb
+++ b/spec/features/contacting_spec.rb
@@ -1,33 +1,33 @@
-# require 'spec_helper'
+require 'spec_helper'
 
-# feature 'Filling out the contact form' do
+feature 'Filling out the contact form' do
 
-#   before do
-#     ENV['VOLUNTEER_SIGNUP_EMAIL_RECIPIENTS'] = 'volunteer@example.com'
-#   end
+  before do
+    ENV['VOLUNTEER_SIGNUP_EMAIL_RECIPIENTS'] = 'volunteer@example.com'
+  end
 
-#   scenario 'User submits a contact request' do
-#     visit '/get-involved' # Can't click on the element for some reason
-#     fill_in 'Name', with: 'Some person'
-#     fill_in 'Company or Organization (optional)', with: 'Acme Corp'
-#     fill_in 'E-mail Address', with: 'test@example.com'
-#     select 'Sponsorship', from: 'What are you interested in?'
-#     fill_in 'Any additional notes?', with: 'Nope'
-#     click_button 'Submit'
-#     expect(page).to have_button('Thanks! We will be in touch shortly', disabled: true)
+  scenario 'User submits a contact request' do
+    visit '/get-involved' # Can't click on the element for some reason
+    fill_in 'Name', with: 'Some person'
+    fill_in 'Company or Organization (optional)', with: 'Acme Corp'
+    fill_in 'E-mail Address', with: 'test@example.com'
+    select 'Sponsorship', from: 'What are you interested in?'
+    fill_in 'Any additional notes?', with: 'Nope'
+    click_button 'Submit'
+    expect(page).to have_button('Thanks! We will be in touch shortly', disabled: true)
 
-#     # Saved to DB
-#     expect(GeneralInquiry.count).to eq(1)
-#     expect(GeneralInquiry.last.contact_email).to eq('test@example.com')
-#     expect(GeneralInquiry.last.contact_name).to eq('Some person')
-#     expect(GeneralInquiry.last.company).to eq('Acme Corp')
-#     expect(GeneralInquiry.last.interest).to eq('sponsorship')
-#     expect(GeneralInquiry.last.notes).to eq('Nope')
+    # Saved to DB
+    expect(GeneralInquiry.count).to eq(1)
+    expect(GeneralInquiry.last.contact_email).to eq('test@example.com')
+    expect(GeneralInquiry.last.contact_name).to eq('Some person')
+    expect(GeneralInquiry.last.company).to eq('Acme Corp')
+    expect(GeneralInquiry.last.interest).to eq('sponsorship')
+    expect(GeneralInquiry.last.notes).to eq('Nope')
 
-#     # Confirmation to volunteers box
-#     expect(last_email_sent).to have_subject('Someone has inquired about DSW')
-#     expect(last_email_sent).to deliver_to('volunteer@example.com')
-#     expect(last_email_sent).to reply_to('test@example.com')
-#   end
+    # Confirmation to volunteers box
+    expect(last_email_sent).to have_subject('Someone has inquired about DSW')
+    expect(last_email_sent).to deliver_to('volunteer@example.com')
+    expect(last_email_sent).to reply_to('test@example.com')
+  end
 
-# end
+end

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -1,84 +1,84 @@
-require "spec_helper"
+# require "spec_helper"
 
-feature "Content-only pages" do
-  scenario "the sponsors page" do
-    pending('refactor')
-    visit "/"
-    click_link "Sponsors"
-    expect(page).to have_content("OUR #{Date.today.year} SPONSORS")
-  end
+# feature "Content-only pages" do
+#   scenario "the sponsors page" do
+#     pending('refactor')
+#     visit "/"
+#     click_link "Sponsors"
+#     expect(page).to have_content("OUR #{Date.today.year} SPONSORS")
+#   end
 
-  scenario "the basecamp page" do
-    visit "/basecamp"
-    expect(page).to have_content("BASECAMP LAUNCHED BY CHASE FOR BUSINESS")
-  end
+#   scenario "the basecamp page" do
+#     visit "/basecamp"
+#     expect(page).to have_content("BASECAMP LAUNCHED BY CHASE FOR BUSINESS")
+#   end
 
-  scenario "the program page" do
-    pending("refactor")
-    visit "/program"
-    expect(page).to have_content("Program")
-  end
+#   scenario "the program page" do
+#     pending("refactor")
+#     visit "/program"
+#     expect(page).to have_content("Program")
+#   end
 
-  scenario "the initiatives page" do
-    visit "/initiatives"
-    expect(page).to have_content("EXPANDING OUR MISSION")
-  end
+#   scenario "the initiatives page" do
+#     visit "/initiatives"
+#     expect(page).to have_content("EXPANDING OUR MISSION")
+#   end
 
-  describe "the get involved section" do
-    scenario "the contact page" do
-      visit "/get-involved"
-      expect(page).to have_content("GET INVOLVED")
-    end
+#   describe "the get involved section" do
+#     scenario "the contact page" do
+#       visit "/get-involved"
+#       expect(page).to have_content("GET INVOLVED")
+#     end
 
-    scenario "the FAQ page" do
-      allow(Helpscout::Article).to receive(:for_category)
-        .and_return([Helpscout::Article.new("name" => "What is 2 + 2?", "text" => "4")])
-      visit "/get-involved"
-      click_link "FAQ"
-      expect(page).to have_content("FREQUENTLY ASKED QUESTIONS")
-      click_button "What is 2 + 2?"
-      expect(page).to have_content("4")
-    end
+#     scenario "the FAQ page" do
+#       allow(Helpscout::Article).to receive(:for_category)
+#         .and_return([Helpscout::Article.new("name" => "What is 2 + 2?", "text" => "4")])
+#       visit "/get-involved"
+#       click_link "FAQ"
+#       expect(page).to have_content("FREQUENTLY ASKED QUESTIONS")
+#       click_button "What is 2 + 2?"
+#       expect(page).to have_content("4")
+#     end
 
-    scenario "the team page" do
-      pending('refactor')
-      visit "/get-involved"
-      click_link "Team"
-      expect(page).to have_content("TEAM")
-    end
+#     scenario "the team page" do
+#       pending('refactor')
+#       visit "/get-involved"
+#       click_link "Team"
+#       expect(page).to have_content("TEAM")
+#     end
 
-    scenario "the content page" do
-      visit "/get-involved"
-      click_link "Content"
-      expect(page).to have_content("SUBMIT & PROMOTE CONTENT")
-    end
-  end
+#     scenario "the content page" do
+#       visit "/get-involved"
+#       click_link "Content"
+#       expect(page).to have_content("SUBMIT & PROMOTE CONTENT")
+#     end
+#   end
 
-  scenario "the assets page" do
-    visit "/"
-    click_link "Press"
-    click_link "Assets"
-    expect(page).to have_content("ASSETS")
-  end
+#   scenario "the assets page" do
+#     visit "/"
+#     click_link "Press"
+#     click_link "Assets"
+#     expect(page).to have_content("ASSETS")
+#   end
 
-  scenario "the press page" do
-    create(:newsroom_item, title: "Good news!", release_date: 1.day.ago, external_link: "http://www.google.com/")
-    visit "/"
-    click_link "Press"
-    expect(page).to have_content("Good news!")
-    click_link "Good news!"
-    expect(current_url).to include("https://www.google.com/")
-  end
+#   scenario "the press page" do
+#     create(:newsroom_item, title: "Good news!", release_date: 1.day.ago, external_link: "http://www.google.com/")
+#     visit "/"
+#     click_link "Press"
+#     expect(page).to have_content("Good news!")
+#     click_link "Good news!"
+#     expect(current_url).to include("https://www.google.com/")
+#   end
 
-  scenario "the code of conduct page" do
-    visit "/"
-    click_link "Code of Conduct"
-    expect(page).to have_content("CODE OF CONDUCT")
-  end
+#   scenario "the code of conduct page" do
+#     visit "/"
+#     click_link "Code of Conduct"
+#     expect(page).to have_content("CODE OF CONDUCT")
+#   end
 
-  scenario "the podcast page" do
-    visit "/"
-    click_link "Podcast"
-    expect(page).to have_content("PODCAST")
-  end
-end
+#   scenario "the podcast page" do
+#     visit "/"
+#     click_link "Podcast"
+#     expect(page).to have_content("PODCAST")
+#   end
+# end

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -26,7 +26,6 @@ feature "Content-only pages" do
 
   describe "the get involved section" do
     scenario "the contact page" do
-      pending('refactor')
       visit "/get-involved"
       expect(page).to have_content("GET INVOLVED")
     end
@@ -50,6 +49,7 @@ feature "Content-only pages" do
     end
 
     scenario "the content page" do
+      pending('refactor')
       visit "/get-involved"
       click_link "Content"
       expect(page).to have_content("SUBMIT & PROMOTE CONTENT")

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -1,84 +1,84 @@
-# require "spec_helper"
+require "spec_helper"
 
-# feature "Content-only pages" do
-#   scenario "the sponsors page" do
-#     pending('refactor')
-#     visit "/"
-#     click_link "Sponsors"
-#     expect(page).to have_content("OUR #{Date.today.year} SPONSORS")
-#   end
+feature "Content-only pages" do
+  scenario "the sponsors page" do
+    pending('refactor')
+    visit "/"
+    click_link "Sponsors"
+    expect(page).to have_content("OUR #{Date.today.year} SPONSORS")
+  end
 
-#   scenario "the basecamp page" do
-#     visit "/basecamp"
-#     expect(page).to have_content("BASECAMP LAUNCHED BY CHASE FOR BUSINESS")
-#   end
+  scenario "the basecamp page" do
+    visit "/basecamp"
+    expect(page).to have_content("BASECAMP LAUNCHED BY CHASE FOR BUSINESS")
+  end
 
-#   scenario "the program page" do
-#     pending("refactor")
-#     visit "/program"
-#     expect(page).to have_content("Program")
-#   end
+  scenario "the program page" do
+    pending("refactor")
+    visit "/program"
+    expect(page).to have_content("Program")
+  end
 
-#   scenario "the initiatives page" do
-#     visit "/initiatives"
-#     expect(page).to have_content("EXPANDING OUR MISSION")
-#   end
+  scenario "the initiatives page" do
+    visit "/initiatives"
+    expect(page).to have_content("EXPANDING OUR MISSION")
+  end
 
-#   describe "the get involved section" do
-#     scenario "the contact page" do
-#       visit "/get-involved"
-#       expect(page).to have_content("GET INVOLVED")
-#     end
+  describe "the get involved section" do
+    scenario "the contact page" do
+      visit "/get-involved"
+      expect(page).to have_content("GET INVOLVED")
+    end
 
-#     scenario "the FAQ page" do
-#       allow(Helpscout::Article).to receive(:for_category)
-#         .and_return([Helpscout::Article.new("name" => "What is 2 + 2?", "text" => "4")])
-#       visit "/get-involved"
-#       click_link "FAQ"
-#       expect(page).to have_content("FREQUENTLY ASKED QUESTIONS")
-#       click_button "What is 2 + 2?"
-#       expect(page).to have_content("4")
-#     end
+    scenario "the FAQ page" do
+      allow(Helpscout::Article).to receive(:for_category)
+        .and_return([Helpscout::Article.new("name" => "What is 2 + 2?", "text" => "4")])
+      visit "/get-involved"
+      click_link "FAQ"
+      expect(page).to have_content("FREQUENTLY ASKED QUESTIONS")
+      click_button "What is 2 + 2?"
+      expect(page).to have_content("4")
+    end
 
-#     scenario "the team page" do
-#       pending('refactor')
-#       visit "/get-involved"
-#       click_link "Team"
-#       expect(page).to have_content("TEAM")
-#     end
+    scenario "the team page" do
+      pending('refactor')
+      visit "/get-involved"
+      click_link "Team"
+      expect(page).to have_content("TEAM")
+    end
 
-#     scenario "the content page" do
-#       visit "/get-involved"
-#       click_link "Content"
-#       expect(page).to have_content("SUBMIT & PROMOTE CONTENT")
-#     end
-#   end
+    scenario "the content page" do
+      visit "/get-involved"
+      click_link "Content"
+      expect(page).to have_content("SUBMIT & PROMOTE CONTENT")
+    end
+  end
 
-#   scenario "the assets page" do
-#     visit "/"
-#     click_link "Press"
-#     click_link "Assets"
-#     expect(page).to have_content("ASSETS")
-#   end
+  scenario "the assets page" do
+    visit "/"
+    click_link "Press"
+    click_link "Assets"
+    expect(page).to have_content("ASSETS")
+  end
 
-#   scenario "the press page" do
-#     create(:newsroom_item, title: "Good news!", release_date: 1.day.ago, external_link: "http://www.google.com/")
-#     visit "/"
-#     click_link "Press"
-#     expect(page).to have_content("Good news!")
-#     click_link "Good news!"
-#     expect(current_url).to include("https://www.google.com/")
-#   end
+  scenario "the press page" do
+    create(:newsroom_item, title: "Good news!", release_date: 1.day.ago, external_link: "http://www.google.com/")
+    visit "/"
+    click_link "Press"
+    expect(page).to have_content("Good news!")
+    click_link "Good news!"
+    expect(current_url).to include("https://www.google.com/")
+  end
 
-#   scenario "the code of conduct page" do
-#     visit "/"
-#     click_link "Code of Conduct"
-#     expect(page).to have_content("CODE OF CONDUCT")
-#   end
+  scenario "the code of conduct page" do
+    visit "/"
+    click_link "Code of Conduct"
+    expect(page).to have_content("CODE OF CONDUCT")
+  end
 
-#   scenario "the podcast page" do
-#     visit "/"
-#     click_link "Podcast"
-#     expect(page).to have_content("PODCAST")
-#   end
-# end
+  scenario "the podcast page" do
+    visit "/"
+    click_link "Podcast"
+    expect(page).to have_content("PODCAST")
+  end
+end

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -26,11 +26,13 @@ feature "Content-only pages" do
 
   describe "the get involved section" do
     scenario "the contact page" do
+      pending('refactor')
       visit "/get-involved"
       expect(page).to have_content("GET INVOLVED")
     end
 
     scenario "the FAQ page" do
+      pending('refactor')
       allow(Helpscout::Article).to receive(:for_category)
         .and_return([Helpscout::Article.new("name" => "What is 2 + 2?", "text" => "4")])
       visit "/get-involved"


### PR DESCRIPTION
* Updated `get-involve` page
* Added routes for `present` and `content` pages
* Created placeholder pages for `present` and `content`
* Changed the redirect for `/faq` from `get-involved/faq` to `about/faq`
* Commented out the test that were being used for the code on the previous `content` page.
* The naming is the buttons right now is not `learn more` but that will be address in my next PR that will allow for button naming to be passed in.