### PR TITLE
added subtitle and description for team page

### DIFF
--- a/app/views/site/about/team.html.slim
+++ b/app/views/site/about/team.html.slim
@@ -1,4 +1,4 @@
-= render layout: 'layouts/shared/secondary_hero', locals: { title: 'About', sub_title: 'By the community, for the community', description: 'Bringing Denver Startup Week to life takes the support, skills, and drive of an entire community: entrepreneurs, investors, civic leaders, educators, business pioneers, and more.' } do
+= render layout: 'layouts/shared/secondary_hero', locals: { title: 'Team', sub_title: 'Lorem Ipsum dolere', description: 'Lorem ipsum dolere sit amet nonummy consecuter adscpecit. Lorem ipsum dolere sit amet nonummy consecuter adscpecit. Lorem ipsum dolere sit amet nonummy consecuter adscpecit. Lorem ipsum dolere sit amet nonummy consecuter adscpecit.' } do
   = render 'layouts/shared/about_secondary_hero_nav'
 
 .TeamList


### PR DESCRIPTION
Updated `title`, `subtitle`,  and `description` on the team page. Currently the mocks are using LOREM IPSUM but Carl is following up.