### PR TITLE
Don’t validate the associated track when creating articles

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,7 +6,7 @@ class Article < ApplicationRecord
   validates :body,
     presence: true
 
-  has_and_belongs_to_many :tracks
+  has_and_belongs_to_many :tracks, validate: false
   belongs_to :author, class_name: "User"
 
   mount_uploader :header_image, HeaderImageUploader


### PR DESCRIPTION
Apparently `validate: true` is the default as of Rails 5 (https://apidock.com/rails/ActiveRecord/Associations/ClassMethods/has_and_belongs_to_many)

/cc @scpaye506