### PR TITLE
Code of conduct update

### DIFF
--- a/app/views/site/code_of_conduct.html.slim
+++ b/app/views/site/code_of_conduct.html.slim
@@ -1,6 +1,7 @@
 -content_for(:fullscreen_takeover, true)
+- on_close = (request.referer =~ /(code-of-conduct)/i).nil? ? request.referer : dashboard_path
 
-= render 'layouts/shared/fullscreen_takeover_header', title: 'Code of Conduct', background: 'light'
+= render 'layouts/shared/fullscreen_takeover_header', title: 'Code of Conduct', background: 'light', on_close: on_close
 = render layout: 'layouts/shared/layout_wrapper' do
   = render layout: 'components/form_wrapper' do
 

--- a/app/views/site/code_of_conduct.html.slim
+++ b/app/views/site/code_of_conduct.html.slim
@@ -1,6 +1,6 @@
 -content_for(:fullscreen_takeover, true)
 - content_for(:subtitle, 'Code of Conduct')
-- on_close = (request.referer =~ /(code-of-conduct)/i).nil? ? request.referer : dashboard_path
+- on_close = request.referer || '/'
 
 = render 'layouts/shared/fullscreen_takeover_header', title: 'Code of Conduct', background: 'light', on_close: on_close
 = render layout: 'layouts/shared/layout_wrapper' do

--- a/app/views/site/code_of_conduct.html.slim
+++ b/app/views/site/code_of_conduct.html.slim
@@ -1,9 +1,6 @@
 -content_for(:fullscreen_takeover, true)
-<<<<<<< HEAD
-- on_close = (request.referer =~ /(code-of-conduct)/i).nil? ? request.referer : dashboard_path
-=======
 - content_for(:subtitle, 'Code of Conduct')
->>>>>>> 7cd79f540595439d026f17b1e3860ae47cf6f26c
+- on_close = (request.referer =~ /(code-of-conduct)/i).nil? ? request.referer : dashboard_path
 
 = render 'layouts/shared/fullscreen_takeover_header', title: 'Code of Conduct', background: 'light', on_close: on_close
 = render layout: 'layouts/shared/layout_wrapper' do


### PR DESCRIPTION
Locally, closing the fullscreen take-over works fine on the `code-of-conduct` page. However, in the staging env, when clicking the close button the user stays on the `code-of-conduct` page. In this PR I am passing `on_close` directly from the `code-of-conduct` page to see if that helps in the staging env.