### PR TITLE
Add ability to edit session from dashboard, and make sessions from da…

### DIFF
--- a/app/assets/stylesheets/redesign/components/session_card.sass
+++ b/app/assets/stylesheets/redesign/components/session_card.sass
@@ -67,3 +67,9 @@
   font-size: 14px
   margin-left: 15px
   text-transform: uppercase
+
+.SessionCard-edit
+  position: absolute
+  top: 15px
+  right: 15px
+  z-index: 2

--- a/app/views/components/_session_card.html.slim
+++ b/app/views/components/_session_card.html.slim
@@ -4,7 +4,11 @@
 
 = render 'components/card' do
   div.SessionCard(class="#{color}-background #{color}-font-on-#{color} #{color}-fill-on-#{color}-background")
-    a.SessionCard-link(href="#{session_link}")
+    - unless local_assigns[:hide_link].present?
+      a.SessionCard-link(href="#{session_link}")
+    - if local_assigns[:editable?].present?
+      = link_to edit_submission_path(session), title: 'Propose Updates', class: 'SessionCard-edit' do
+        = render partial: 'icons/pencil'
     div.SessionCard-type
       = render partial: "icons/#{icon}"
       span.SessionCard-name #{session.track[:name]}

--- a/app/views/dashboards/show.html.slim
+++ b/app/views/dashboards/show.html.slim
@@ -48,7 +48,7 @@
       ul.Dashboard-card-list(aria-labelledby="my-sessions")
         - @submissions.each do |submission|
           li.Dashboard-card-list-item
-            = render partial: 'components/session_card', locals: { session: submission }
+            = render partial: 'components/session_card', locals: { session: submission, editable?: submission.editable?, hide_link: true }
     - if @submissions.blank?
       .Dashboard-empty-message You have not yet submitted any proposals for this year.
 
@@ -82,7 +82,7 @@
       ul.Dashboard-card-list(aria-labelledby="my-previous-sessions")
         - @previous_submissions.each do |submission|
           li.Dashboard-card-list-item
-            = render partial: 'components/session_card', locals: { session: submission }
+            = render partial: 'components/session_card', locals: { session: submission,  hide_link: true }
 
 
 / = render partial: 'nav', locals: { item: :mine }


### PR DESCRIPTION
…shboard not linkable

There are only public show views for sessions and if a session is not in a public state then it will throw a 500 error when a user clicks a session from their dashboard. So, i've just removed the ability for a user to view the session detail from their dashboard