### PR TITLE
Sponsors height

### DIFF
--- a/app/assets/stylesheets/redesign/components/sponsors_card.sass
+++ b/app/assets/stylesheets/redesign/components/sponsors_card.sass
@@ -43,6 +43,11 @@
   line-height: 18px
   font-size: 14px
   font-weight: 300
+  display: -webkit-box
+  -webkit-line-clamp: 7
+  -webkit-box-orient: vertical
+  overflow: hidden
+  text-overflow: ellipsis
 
 .SponsorsCard-action
   margin-top: 12px
@@ -80,6 +85,10 @@
   margin-top: 20px
   & span
     margin-left: 5px
+
+.SponsorsCard-track + .SponsorsCard-inner-content
+  p
+    -webkit-line-clamp: 6
 
 @media(min-width: 640px)
   .SponsorsCard-description

--- a/app/assets/stylesheets/redesign/components/sponsors_card.sass
+++ b/app/assets/stylesheets/redesign/components/sponsors_card.sass
@@ -86,9 +86,13 @@
   & span
     margin-left: 5px
 
-.SponsorsCard-track + .SponsorsCard-inner-content
+.track .SponsorsCard-inner-content
   p
     -webkit-line-clamp: 6
+
+.headline .SponsorsCard-inner-content
+  p
+    -webkit-line-clamp: 4
 
 @media(min-width: 640px)
   .SponsorsCard-description

--- a/app/assets/stylesheets/redesign/components/sponsors_card.sass
+++ b/app/assets/stylesheets/redesign/components/sponsors_card.sass
@@ -97,3 +97,11 @@
 @media(min-width: 640px)
   .SponsorsCard-description
     margin-top: 26px
+  .SponsorsCard-description
+    min-height: 9em
+  .track .SponsorsCard-inner-content
+    p
+      min-height: 7.75em
+  .headline .SponsorsCard-inner-content
+    p
+     min-height: 5.25em

--- a/app/views/components/_sponsors_card.html.slim
+++ b/app/views/components/_sponsors_card.html.slim
@@ -1,4 +1,4 @@
-- header_image = sponsorship.logo.url || ""
+- header_image = sponsorship.logo.url || "https://cdn-images-1.medium.com/max/800/1*amnvhplMQHkIrq_iYD8GUA.jpeg"
 
 .SponsorsCard
   div.(class="SponsorsCard-image #{level}" style="background-image: url(#{image_url header_image})")

--- a/app/views/components/_sponsors_card.html.slim
+++ b/app/views/components/_sponsors_card.html.slim
@@ -1,4 +1,4 @@
-- header_image = sponsorship.logo.url || "https://cdn-images-1.medium.com/max/800/1*amnvhplMQHkIrq_iYD8GUA.jpeg"
+- header_image = sponsorship.logo.url || ""
 
 .SponsorsCard
   div.(class="SponsorsCard-image #{level}" style="background-image: url(#{image_url header_image})")


### PR DESCRIPTION
added min-height for sponsors `p` tag for desktop. This forces sponsors of the same type to be the same height, regardless of description length. In mobile, each sponsors card is still responsive based on content in description up until the line limit. 

Added line limit as per Bryan's comment and according to the mocks.