### PR TITLE
primary calllout nav now displays in block in windows

### DIFF
--- a/app/assets/stylesheets/redesign/layouts/primary_callouts_nav.sass
+++ b/app/assets/stylesheets/redesign/layouts/primary_callouts_nav.sass
@@ -47,3 +47,8 @@
 
     &:last-child
       border-bottom: 0
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active)
+  /* IE10+ CSS styles go here */
+  .PrimaryCalloutsNav-list-item
+    display: block

--- a/app/assets/stylesheets/redesign/layouts/primary_callouts_nav.sass
+++ b/app/assets/stylesheets/redesign/layouts/primary_callouts_nav.sass
@@ -29,6 +29,7 @@
 
 .PrimaryCalloutsNav-list-desc
   flex: 1
+  flex-basis: auto
   font-size: 14px
   font-weight: 300
   color: $primary-font-medium
@@ -47,8 +48,3 @@
 
     &:last-child
       border-bottom: 0
-
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active)
-  /* IE10+ CSS styles go here */
-  .PrimaryCalloutsNav-list-item
-    display: block


### PR DESCRIPTION
in `IE11` the `height` of the `flex` container was collapsing so I changed it to `display: block` and it now looks fine. One note is that on `IE11` each `li` in the `primary_callouts_nav.html.slim` can now have a different height, since it is display `block` instead of `flex`. Meaning, the arrow buttons may not lineup at the bottom.