### PR TITLE
Truncate articles in an html-safe way

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "liquid"
 gem "mini_magick"
 gem "rinku"
 gem "sanitize"
+gem "truncato"
 
 gem "premailer-rails"
 gem "retries"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,6 +497,9 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    truncato (0.7.11)
+      htmlentities (~> 4.3.1)
+      nokogiri (>= 1.7.0, <= 2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (3.0.0)
@@ -596,6 +599,7 @@ DEPENDENCIES
   slim-rails
   standardrb
   textacular
+  truncato
   uglifier
   utf8-cleaner
   validate_url

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,57 +1,50 @@
 module ApplicationHelper
-
   def process_with_liquid(content)
     context = {
-      'submission_open_date' =>
-        AnnualSchedule
-          .current
-          .cfp_open_at
-          .try(:in_time_zone, ActiveSupport::TimeZone['America/Denver'])
-          .try(:at_beginning_of_day),
-      'submission_close_date' =>
-        AnnualSchedule
-          .current
-          .cfp_close_at
-          .try(:in_time_zone, ActiveSupport::TimeZone['America/Denver'])
-          .try(:at_end_of_day),
-      'voting_open_date' =>
-        AnnualSchedule
-          .current
-          .voting_open_at
-          .try(:in_time_zone, ActiveSupport::TimeZone['America/Denver'])
-          .try(:at_beginning_of_day),
-      'voting_close_date' =>
-        AnnualSchedule
-          .current
-          .voting_close_at
-          .try(:in_time_zone, ActiveSupport::TimeZone['America/Denver'])
-          .try(:at_end_of_day),
-      'registration_open_date' =>
-        AnnualSchedule
-          .current
-          .registration_open_at
-          .try(:in_time_zone, ActiveSupport::TimeZone['America/Denver'])
-          .try(:at_beginning_of_day),
-      'week_start_date' =>
-        AnnualSchedule
-          .current
-          .week_start_at
-          .try(:in_time_zone, ActiveSupport::TimeZone['America/Denver'])
-          .try(:at_beginning_of_day),
-      'current_date' => DateTime.now
+      "submission_open_date" => AnnualSchedule
+        .current
+        .cfp_open_at
+        .try(:in_time_zone, ActiveSupport::TimeZone["America/Denver"])
+        .try(:at_beginning_of_day),
+      "submission_close_date" => AnnualSchedule
+        .current
+        .cfp_close_at
+        .try(:in_time_zone, ActiveSupport::TimeZone["America/Denver"])
+        .try(:at_end_of_day),
+      "voting_open_date" => AnnualSchedule
+        .current
+        .voting_open_at
+        .try(:in_time_zone, ActiveSupport::TimeZone["America/Denver"])
+        .try(:at_beginning_of_day),
+      "voting_close_date" => AnnualSchedule
+        .current
+        .voting_close_at
+        .try(:in_time_zone, ActiveSupport::TimeZone["America/Denver"])
+        .try(:at_end_of_day),
+      "registration_open_date" => AnnualSchedule
+        .current
+        .registration_open_at
+        .try(:in_time_zone, ActiveSupport::TimeZone["America/Denver"])
+        .try(:at_beginning_of_day),
+      "week_start_date" => AnnualSchedule
+        .current
+        .week_start_at
+        .try(:in_time_zone, ActiveSupport::TimeZone["America/Denver"])
+        .try(:at_beginning_of_day),
+      "current_date" => DateTime.now,
     }
     template = Liquid::Template.parse(content)
     template.render(context)
   end
 
   def process_with_pipeline(content)
-    context = { asset_root: '/images/icons' }
+    context = {asset_root: "/images/icons"}
     pipeline = HTML::Pipeline.new(
       [
         HTML::Pipeline::MarkdownFilter,
         HTML::Pipeline::EmojiFilter,
         HTML::Pipeline::SanitizationFilter,
-        HTML::Pipeline::AutolinkFilter
+        HTML::Pipeline::AutolinkFilter,
       ],
       context
     )
@@ -81,15 +74,15 @@ module ApplicationHelper
     full_hours = hours.floor
     minutes = (hours - full_hours) * 60
     full_minutes = minutes.floor
-    "#{full_days} : #{full_hours.to_s.rjust(2, '0')} : #{full_minutes.to_s.rjust(2, '0')}"
+    "#{full_days} : #{full_hours.to_s.rjust(2, "0")} : #{full_minutes.to_s.rjust(2, "0")}"
   end
 
   def tracks_for_select
-    Track.submittable.in_display_order.map { |t| [ t.name, t.id ] }
+    Track.submittable.in_display_order.map { |t| [t.name, t.id] }
   end
 
   def clusters_for_select
-    Cluster.in_display_order.map { |c| [ c.name, c.id ] }
+    Cluster.in_display_order.map { |c| [c.name, c.id] }
   end
 
   def age_ranges_for_select
@@ -105,40 +98,40 @@ module ApplicationHelper
       .for_current_year
       .for_schedule
       .joins(:track)
-      .where(tracks: { name: 'Basecamp' })
+      .where(tracks: {name: "Basecamp"})
   end
 
   def sponsorships_by_level
     @sponsorships_by_level ||= Sponsorship
-                               .for_current_year
-                               .for_sponsors_page
-                               .alphabetical
-                               .includes(:track, submission: :track)
-                               .group_by(&:level)
+      .for_current_year
+      .for_sponsors_page
+      .alphabetical
+      .includes(:track, submission: :track)
+      .group_by(&:level)
   end
 
   def ambassador_host_company_sponsorships
     @ambassador_host_company_sponsorships ||= Sponsorship
-                                              .for_current_year
-                                              .where(level: Sponsorship::AMBASSADOR_HOST_LEVEL)
-                                              .alphabetical
-                                              .includes(:track, submission: :track)
+      .for_current_year
+      .where(level: Sponsorship::AMBASSADOR_HOST_LEVEL)
+      .alphabetical
+      .includes(:track, submission: :track)
   end
 
   def ambassador_sponsorships
     @ambassador_sponsorships ||= Sponsorship
-                                 .for_current_year
-                                 .where(level: Sponsorship::AMBASSADOR_SPONSOR_LEVEL)
-                                 .alphabetical
-                                 .includes(:track, submission: :track)
+      .for_current_year
+      .where(level: Sponsorship::AMBASSADOR_SPONSOR_LEVEL)
+      .alphabetical
+      .includes(:track, submission: :track)
   end
 
   def ambassador_partners
     @ambassador_partners ||= Sponsorship
-                             .for_current_year
-                             .where(level: Sponsorship::AMBASSADOR_PARTNER_LEVEL)
-                             .alphabetical
-                             .includes(:track, submission: :track)
+      .for_current_year
+      .where(level: Sponsorship::AMBASSADOR_PARTNER_LEVEL)
+      .alphabetical
+      .includes(:track, submission: :track)
   end
 
   def footer_sponsors
@@ -147,24 +140,24 @@ module ApplicationHelper
 
   def podcast_sponsorships
     @podcast_sponsorships ||= Sponsorship
-                              .for_current_year
-                              .where(level: Sponsorship::PODCAST_LEVEL)
-                              .alphabetical
-                              .includes(:track, submission: :track)
+      .for_current_year
+      .where(level: Sponsorship::PODCAST_LEVEL)
+      .alphabetical
+      .includes(:track, submission: :track)
   end
 
   def pitch_sponsors
     @pitch_sponsors ||= Sponsorship
-                        .for_current_year
-                        .where(level: Sponsorship::PITCH_LEVEL)
-                        .alphabetical
+      .for_current_year
+      .where(level: Sponsorship::PITCH_LEVEL)
+      .alphabetical
   end
 
   def field_guide_sponsors
     @field_guide_sponsors ||= Sponsorship
-                              .for_current_year
-                              .where(level: Sponsorship::FIELD_GUIDE_LEVEL)
-                              .alphabetical
+      .for_current_year
+      .where(level: Sponsorship::FIELD_GUIDE_LEVEL)
+      .alphabetical
   end
 
   def helpscout_articles_for_category(category_name)
@@ -173,5 +166,9 @@ module ApplicationHelper
 
   def registration_open?
     AnnualSchedule.registration_open?
+  end
+
+  def truncate_html(content, max_length)
+    Truncato.truncate(content, max_length: max_length, count_tags: false)
   end
 end

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -6,7 +6,7 @@
   meta(property="og:image" content="#{@article.header_image.url(:article_card)}")
   meta(property="og:site_name" content="Denver Startup Week")
   meta(property="og:url" content="#{article_path(@article)}")
-  meta(property="og:description" content="#{truncate(@article.body.html_safe, length: 300, separator: ' ')}")
+  meta(property="og:description" content="#{truncate_html(@article.body, 300).html_safe}")
   meta(name="date" content="#{@article.publishing.effective_at.strftime("%A, %b%e, %Y")}")
 
 .Article

--- a/app/views/components/_article_card.html.slim
+++ b/app/views/components/_article_card.html.slim
@@ -8,9 +8,9 @@
         .ArticleCard-date #{article.publishing.effective_at.strftime("%b%e, %Y")}
       - else
         .ArticleCard-date Not Yet Published
-      h2.ArticleCard-title #{article[:title]}
+      h2.ArticleCard-title #{article.title}
       - unless article.header_image.present?
-        .ArticleCard-body-preview #{article[:body].truncate(175).html_safe}
+        .ArticleCard-body-preview #{truncate_html(article.body, 175).html_safe}
       .ArticleCard-tracks
         - article.tracks.limit(3).each do |track|
           =render partial: 'components/track_indicator', locals: { size: 'small', color: "#{track[:color]}", name: "#{track[:name]}" }


### PR DESCRIPTION
Using the [truncato gem](https://github.com/jorgemanrubia/truncato) - this isn't in Rails core anymore.

This should solve some formatting weirdness in the preview environment:
![Screen Shot 2019-07-12 at 11 15 32 AM](https://user-images.githubusercontent.com/22783/61146177-a3b35780-a496-11e9-87ee-0eb362fbd4c3.png)
