### PR TITLE
Fix up Textacular query for publishings

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -56,7 +56,7 @@ class Article < ApplicationRecord
       body: terms,
       users: {name: terms},
     }
-    joins(:authors).basic_search(predicate, false)
+    left_outer_joins(:authors).basic_search(predicate, false)
   end
 
   def self.published

--- a/app/models/publishing.rb
+++ b/app/models/publishing.rb
@@ -2,8 +2,8 @@ class Publishing < ApplicationRecord
   belongs_to :subject, polymorphic: true
 
   def self.filtered_results(filters)
-    article_ids = Article.for_publishings_filter(filters).to_a.pluck(:id)
-    session_ids = Submission.for_publishings_filter(filters).to_a.pluck(:id)
+    article_ids = Article.for_publishings_filter(filters).reorder(nil).except(:select).select(:id)
+    session_ids = Submission.for_publishings_filter(filters).reorder(nil).except(:select).select(:id)
     where(subject_type: "Article", subject_id: article_ids)
       .or(where(subject_type: "Submission", subject_id: session_ids))
       .reorder("publishings.effective_at" => :desc)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -86,5 +86,7 @@ FactoryBot.define do
     association :submitter, factory: :user
   end
 
-  factory :publishing
+  factory :publishing do
+    effective_at { Time.zone.now }
+  end
 end

--- a/spec/models/publishing_spec.rb
+++ b/spec/models/publishing_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe Publishing, type: :model do
+  before do
+    allow(ListSubscriptionJob).to receive(:perform_async)
+  end
+
+  it { is_expected.to belong_to(:subject) }
+
+  describe "filtering results" do
+    let!(:article) { create(:article, title: "Hello", body: "world") }
+    let!(:article_publishing) { create(:publishing, subject: article) }
+    let!(:submission) { create(:submission, title: "Talk", description: "Tech") }
+    let!(:submission_publishing) { create(:publishing, subject: submission) }
+
+    it "allows a search with no criteria, returning all results" do
+      results = Publishing.filtered_results({})
+      expect(results.count).to eq(2)
+    end
+
+    it "allows a search on article title" do
+      results = Publishing.filtered_results(terms: "hello")
+      expect(results.count).to eq(1)
+      expect(results.first.subject).to eq(article)
+    end
+
+    it "allows a search on article body" do
+      results = Publishing.filtered_results(terms: "world")
+      expect(results.count).to eq(1)
+      expect(results.first.subject).to eq(article)
+    end
+
+    it "allows a search on article author" do
+      article.authors << create(:user, name: "John Doe")
+      results = Publishing.filtered_results(terms: "Doe")
+      expect(results.count).to eq(1)
+      expect(results.first.subject).to eq(article)
+    end
+
+    it "allows a search on session title" do
+      results = Publishing.filtered_results(terms: "talk")
+      expect(results.count).to eq(1)
+      expect(results.first.subject).to eq(submission)
+    end
+
+    it "allows a search on session description" do
+      results = Publishing.filtered_results(terms: "tech")
+      expect(results.count).to eq(1)
+      expect(results.first.subject).to eq(submission)
+    end
+  end
+end


### PR DESCRIPTION
- The subquery column error was coming up because of this line in Textacular where it explicitly sets select/order: https://github.com/textacular/textacular/blob/master/lib/textacular.rb#L127, also referenced in https://github.com/textacular/textacular/issues/86. This commit reorders/excludes those criteria to allow the Textacular query to just return an ID, which is what the `IN` requires.
- Also fix a bug where posts without authors were not findable due to the inner join
- Add tests too!

Fixes https://github.com/denverstartupweek/dsw-site/issues/513