### PR TITLE
More robust solution for FST close button

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,8 +33,7 @@ class ApplicationController < ActionController::Base
     return unless request.get?
     return if devise_controller?
     return if request.xhr?
-    session[:close_fst_url] = session[:after_auth_url]
-    session[:after_auth_url] = request.fullpath
+    session[:previous_url] = request.fullpath
   end
 
   def configure_permitted_parameters
@@ -52,7 +51,7 @@ class ApplicationController < ActionController::Base
 
   def ensure_registered!
     unless current_registration
-      session[:after_registration_path] = session[:after_auth_url]
+      session[:after_registration_path] = session[:previous_url]
       redirect_to main_app.new_registration_path
     end
   end
@@ -90,8 +89,8 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(user)
     if params[:register_to_attend] == "true"
       new_registration_path
-    elsif session[:after_auth_url]
-      session[:after_auth_url]
+    elsif session[:previous_url]
+      session[:previous_url]
     elsif user.registered?
       main_app.schedules_path
     elsif AnnualSchedule.registration_open?

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,4 +1,5 @@
 class ArticlesController < ApplicationController
+  skip_before_action :store_location, only: %i[new edit]
   before_action :authenticate_user!, only: %i[new create update edit]
 
   def index

--- a/app/controllers/general_inquiries_controller.rb
+++ b/app/controllers/general_inquiries_controller.rb
@@ -1,4 +1,6 @@
 class GeneralInquiriesController < ApplicationController
+  skip_before_action :store_location, only: %i[new]
+
   def new
     @general_inquiry = GeneralInquiry.new
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,6 @@
 class RegistrationsController < ApplicationController
 
+  skip_before_action :store_location, only: %i[new closed]
   before_action :check_registration_open, except: [ :closed ]
   before_action :authenticate_user!, unless: :simple_registration?, except: [ :closed ]
   before_action :check_existing_registration, unless: :simple_registration?, except: [ :closed ]

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,6 +1,7 @@
 class SubmissionsController < ApplicationController
   respond_to :html,
     :atom
+  skip_before_action :store_location, only: %i[new edit feedback_closed submissions_closed]
   before_action :check_cfp_open, only: %i[new create]
   before_action :authenticate_user!, only: %i[new create mine submissions_closed]
   before_action :check_voting_open, only: %i[index show]

--- a/app/helpers/route_helper.rb
+++ b/app/helpers/route_helper.rb
@@ -242,8 +242,8 @@ module RouteHelper
   end
 
   def came_from_registration?
-    session[:after_auth_url] == new_registration_path ||
-      session[:after_auth_url] == register_path
+    session[:previous_url] == new_registration_path ||
+      session[:previous_url] == register_path
   end
 
   def came_from_program_tracks?

--- a/app/views/layouts/shared/_fullscreen_takeover_header.html.slim
+++ b/app/views/layouts/shared/_fullscreen_takeover_header.html.slim
@@ -1,5 +1,4 @@
-- close_action = local_assigns[:on_close].present? ? local_assigns[:on_close] : session[:close_fst_url] || '/'
-
+- close_action = request.fullpath == session[:previous_url] ? (request.referer || '/') : (session[:previous_url] || '/')
 header.FullscreenTakeoverHeader(class="is-#{background}")
   = render layout: 'layouts/shared/layout_wrapper' do
     .FullscreenTakeoverHeader-inner

--- a/app/views/registrations/new.html.slim
+++ b/app/views/registrations/new.html.slim
@@ -3,9 +3,7 @@
 - content_for :extra_body_tags do
   = stylesheet_pack_tag 'application'
 
-- on_close = (request.referer =~ /(sign_in|sign_up)/i).nil? ? request.referer : dashboard_path
-
-= render 'layouts/shared/fullscreen_takeover_header', title: 'register to attend', background: 'dark', on_close: on_close
+= render 'layouts/shared/fullscreen_takeover_header', title: 'register to attend', background: 'dark'
 = render layout: 'layouts/shared/layout_wrapper' do
   = render layout: 'components/form_wrapper' do
     = form_for(@registration, method: :post, url: registration_path, honeypot: true) do |f|

--- a/app/views/submissions/edit.html.slim
+++ b/app/views/submissions/edit.html.slim
@@ -1,6 +1,6 @@
 - content_for(:fullscreen_takeover, true)
 
-= render 'layouts/shared/fullscreen_takeover_header', title: 'Update Session', background: 'light', on_close: '/dashboard'
+= render 'layouts/shared/fullscreen_takeover_header', title: 'Update Session', background: 'light'
 = render layout: 'layouts/shared/layout_wrapper' do
 
   = render layout: 'components/form_wrapper' do

--- a/app/views/submissions/submissions_closed.html.slim
+++ b/app/views/submissions/submissions_closed.html.slim
@@ -1,6 +1,6 @@
 - content_for(:fullscreen_takeover, true)
 
-= render 'layouts/shared/fullscreen_takeover_header', title: 'Submit Session', background: 'light', on_close: '/get-involved'
+= render 'layouts/shared/fullscreen_takeover_header', title: 'Submit Session', background: 'light'
 = render layout: 'layouts/shared/layout_wrapper' do
 
   h3 Session submissions for #{current_year} are currently closed


### PR DESCRIPTION
skipping the store_location action on any FST controllers should make closing them a lot more consistent