### PR TITLE
Fix re-direct to register after signup/signin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,7 @@ class ApplicationController < ActionController::Base
     return unless request.get?
     return if devise_controller?
     return if request.xhr?
+    session[:came_from_registration] = false
     session[:previous_url] = request.fullpath
   end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,6 +1,7 @@
 class RegistrationsController < ApplicationController
 
   skip_before_action :store_location, only: %i[new closed]
+  before_action :set_came_from_registration, only: %i[new]
   before_action :check_registration_open, except: [ :closed ]
   before_action :authenticate_user!, unless: :simple_registration?, except: [ :closed ]
   before_action :check_existing_registration, unless: :simple_registration?, except: [ :closed ]
@@ -64,5 +65,9 @@ class RegistrationsController < ApplicationController
     if params[:after_registration_path].present?
       session[:after_registration_path] = params[:after_registration_path]
     end
+  end
+
+  def set_came_from_registration
+    session[:came_from_registration] = true
   end
 end

--- a/app/helpers/route_helper.rb
+++ b/app/helpers/route_helper.rb
@@ -242,8 +242,7 @@ module RouteHelper
   end
 
   def came_from_registration?
-    session[:previous_url] == new_registration_path ||
-      session[:previous_url] == register_path
+    session[:came_from_registration]
   end
 
   def came_from_program_tracks?

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -48,6 +48,9 @@
       - if registration_open? && !came_from_registration?
         = render partial: 'components/register_to_attend_radio'
 
+      - if registration_open? && came_from_registration?
+        input(type="hidden" value="true" name="register_to_attend")
+
       .SignUp-actions
         div.SignUp-link-wrapper
           | Already have an account?

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -25,6 +25,9 @@
       - if registration_open? && !came_from_registration?
         = render partial: 'components/register_to_attend_radio'
 
+      - if registration_open? && came_from_registration?
+        input(type="hidden" value="true" name="register_to_attend")
+
       .SignIn-actions
         div.SignIn-link-wrapper
           | Don't have an account?


### PR DESCRIPTION
i broke the registration redirects from register to signup and back to register with the fullscreen takeover fix from earlier today. This fixes that.