### PR TITLE
Set a height for the article page image version

### DIFF
--- a/app/uploaders/header_image_uploader.rb
+++ b/app/uploaders/header_image_uploader.rb
@@ -26,7 +26,7 @@ class HeaderImageUploader < CarrierWave::Uploader::Base
   end
 
   version :article_page do
-    process resize_to_limit: [1070 * 2, nil]
+    process resize_to_fill: [1092 * 2, 464 * 2]
   end
 
   version :content_card do


### PR DESCRIPTION
Should help prevent it from being distorted.

The article list card images are positioned with background-image/background-position, so they don't need this treatment. If we want to go that direction with the article page headers too, we can always revert this.

Will need to reprocess images once this is deployed as well.