### PR TITLE
Show an abbreviated name for session attendees

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,4 +59,13 @@ class User < ApplicationRecord
   def initials
     name.split(" ").map { |n| n[0, 1] }.join
   end
+
+  def abbreviated_name
+    parts = name.split
+    if parts.size > 1
+      [parts.first, parts.last[0]].compact.join(" ") + "."
+    else
+      name
+    end
+  end
 end

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -30,7 +30,7 @@
     .Article-authors
       - @article.authors.each do |author|
         .Article-author
-          = render partial: 'components/name_with_avatar', locals: { user: author, align: 'right', color: 'grey' }
+          = render partial: 'components/name_with_avatar', locals: { user: author, name: author.name, align: 'right', color: 'grey' }
     - if @article.video_url.present?
       .Article-video
         iframe id="ytplayer-#{@article.id}" type="text/html" width="100%" class="Article-video-iframe" src="#{@article.embed_video_url}" frameborder="0"

--- a/app/views/components/_name_with_avatar.html.slim
+++ b/app/views/components/_name_with_avatar.html.slim
@@ -1,3 +1,3 @@
 .NameWithAvatar(class="is-#{align} #{color}-font")
-  .NameWithAvatar-name #{user.name}
+  .NameWithAvatar-name #{name}
   = render partial: 'components/avatar', locals: { size: 'small', color: color,  user: user }

--- a/app/views/layouts/shared/_header.html.slim
+++ b/app/views/layouts/shared/_header.html.slim
@@ -7,7 +7,7 @@ header#site-header-js.Header
       .Header-profile-actions
         - if signed_in?
           a href="#{dashboard_path}"
-            = render partial: 'components/name_with_avatar', locals: { user: current_user, align: 'left', color: 'teal-light' }
+            = render partial: 'components/name_with_avatar', locals: { user: current_user, name: current_user.name, align: 'left', color: 'teal-light' }
         - else
           = link_to "Sign Up / Sign In", new_user_registration_path, class: 'Header-signup'
       button.Header-button.Header-button-open#menu-open-button-js.Header-menu-button(aria-label="Open Main Menu")

--- a/app/views/schedules/show.html.slim
+++ b/app/views/schedules/show.html.slim
@@ -69,7 +69,7 @@
         - if user_signed_in?
           - @session.public_registrants(current_user).each do |user|
             .SessionDetail-attendee
-              = render partial: 'components/name_with_avatar', locals: { user: user, align: 'right', color: 'gray' }
+              = render partial: 'components/name_with_avatar', locals: { user: user, name: user.abbreviated_name, align: 'right', color: 'gray' }
               - if user[:linkedin_url].present?
                 = render partial: 'components/user_linkedin', locals: { user: user }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,4 +24,48 @@ RSpec.describe User, type: :model do
 
     it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
   end
+
+  describe "deriving initials" do
+    it "works when a first and last name are specified" do
+      u = build(:user, name: "Jay Zeschin")
+      expect(u.initials).to eq("JZ")
+    end
+
+    it "doesn't explode when a name is empty" do
+      u = build(:user, name: "")
+      expect(u.initials).to be_blank
+    end
+
+    it "works when only a first name is specified" do
+      u = build(:user, name: "Jay")
+      expect(u.initials).to eq("J")
+    end
+
+    it "works when multiple last names are specified" do
+      u = build(:user, name: "Jay Zeschin Smith")
+      expect(u.initials).to eq("JZS")
+    end
+  end
+
+  describe "deriving an abbreviated name" do
+    it "works when a first and last name are specified" do
+      u = build(:user, name: "Jay Zeschin")
+      expect(u.abbreviated_name).to eq("Jay Z.")
+    end
+
+    it "works when only a first name is specified" do
+      u = build(:user, name: "Jay")
+      expect(u.abbreviated_name).to eq("Jay")
+    end
+
+    it "works when multiple last names are specified" do
+      u = build(:user, name: "Jay Zeschin Smith")
+      expect(u.abbreviated_name).to eq("Jay S.")
+    end
+
+    it "doesn't explode when a name is empty" do
+      u = build(:user, name: "")
+      expect(u.abbreviated_name).to be_blank
+    end
+  end
 end


### PR DESCRIPTION
e.g. “Jay Z.” Instead of “Jay Zeschin”

Fixes #621