### PR TITLE
Disable sorting on count columns in admin

### DIFF
--- a/app/admin/submissions.rb
+++ b/app/admin/submissions.rb
@@ -76,8 +76,8 @@ ActiveAdmin.register Submission do
       status_tag s.state.to_s.titleize, class: status_for_submission(s)
     end
     column :submitter, sortable: "users.name"
-    column(:votes, sortable: "COUNT(votes.id)") { |s| s.votes.size }
-    column(:attendees, sortable: "COUNT(user_registrations.id)") { |s| s.user_registrations.size }
+    column(:votes, sortable: false) { |s| s.votes.size }
+    column(:attendees, sortable: false) { |s| s.user_registrations.size }
     column(:pending_updates, sortable: false) { |s| s.proposed_updates.present? ? "Yes" : "No" }
     column "Published" do |submission|
       submission.published? ? submission&.publishing&.effective_at : "No"


### PR DESCRIPTION
This didn’t actually work before and was actively misleading.

There doesn’t appear to be a good way to do this natively in AA, unfortunately.