### PR TITLE
Fix sort order for dashboard schedule

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -10,7 +10,7 @@ class DashboardsController < ApplicationController
       .for_year(Date.today.year)
       .for_schedule
       .my_schedule(current_user)
-      .order(:start_hour)
+      .order(start_day: :asc, start_hour: :asc)
       .includes(:venue,
         :submitter,
         :track,


### PR DESCRIPTION
Sort sessions by day and time with explicit sort order for each