### PR TITLE
Fix flapping content page specs

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -58,53 +58,65 @@ feature "Content-only pages" do
     expect(page).to have_content("CODE OF CONDUCT")
   end
 
-  describe "browsing clusters" do
-    let!(:cluster) { create(:cluster, name: "Business") }
-    let!(:submission) do
-      create(:submission,
-        cluster: cluster,
-        title: "Finance 101",
-        state: "confirmed",
-        start_day: 2,
-        start_hour: 10,
-        end_day: 2,
-        end_hour: 11)
+  describe "inside the registration period" do
+    before do
+      travel_to AnnualSchedule.current.registration_open_at.to_datetime + 1.day
     end
 
-    scenario "should be able to view a list of clusters and drill into detail pages" do
-      visit "/"
-      click_button "Open Main Menu"
-      click_link "Program"
-      click_link "Clusters"
-      expect(page).to have_css(".ContentCard", text: "BUSINESS")
-      click_link "Explore Business"
-      click_link "View Business Session"
-      expect(page).to have_css(".ScheduledSession", text: "Finance 101")
-    end
-  end
-
-  describe "browsing tracks" do
-    let!(:track) { create(:track, name: "Business") }
-    let!(:submission) do
-      create(:submission,
-        track: track,
-        title: "Finance 101",
-        state: "confirmed",
-        start_day: 2,
-        start_hour: 10,
-        end_day: 2,
-        end_hour: 11)
+    after do
+      travel_back
     end
 
-    scenario "should be able to view a list of tracks and drill into detail pages" do
-      visit "/"
-      click_button "Open Main Menu"
-      click_link "Program"
-      click_link "Tracks"
-      expect(page).to have_css(".ContentCard", text: "BUSINESS")
-      click_link "Explore Business"
-      click_link "View Business Session"
-      expect(page).to have_css(".ScheduledSession", text: "Finance 101")
+    describe "browsing clusters" do
+      let!(:cluster) { create(:cluster, name: "Business") }
+      let!(:submission) do
+        create(:submission,
+          cluster: cluster,
+          title: "Finance 101",
+          state: "confirmed",
+          start_day: 2,
+          start_hour: 10,
+          end_day: 2,
+          end_hour: 11,
+          year: AnnualSchedule.current.registration_open_at.year)
+      end
+
+      scenario "should be able to view a list of clusters and drill into detail pages" do
+        visit "/"
+        click_button "Open Main Menu"
+        click_link "Program"
+        click_link "Clusters"
+        expect(page).to have_css(".ContentCard", text: "BUSINESS")
+        click_link "Explore Business"
+        click_link "View Business Sessions"
+        expect(page).to have_css(".ScheduledSession", text: "Finance 101")
+      end
+    end
+
+    describe "browsing tracks" do
+      let!(:track) { create(:track, name: "Business") }
+      let!(:submission) do
+        create(:submission,
+          track: track,
+          title: "Finance 101",
+          state: "confirmed",
+          start_day: 2,
+          start_hour: 10,
+          end_day: 2,
+          end_hour: 11,
+          year: AnnualSchedule.current.registration_open_at.year)
+      end
+
+      scenario "should be able to view a list of tracks and drill into detail pages" do
+        visit "/"
+        click_button "Open Main Menu"
+        click_link "Program"
+        click_link "Tracks"
+        expect(page).to have_css(".ContentCard", text: "BUSINESS")
+        click_link "Explore Business"
+        click_link "View Business Sessions"
+        expect(page).to have_css(".ScheduledSession", text: "Finance 101")
+      end
     end
   end
 end

--- a/spec/features/giving_feedback_spec.rb
+++ b/spec/features/giving_feedback_spec.rb
@@ -37,6 +37,10 @@ feature "Giving feedback on a session" do
       travel_to AnnualSchedule.current.week_start_at + 1.day
     end
 
+    after do
+      travel_back
+    end
+
     scenario "a user provides feedback for a session when already signed in and registered" do
       login_as user, scope: :user
 
@@ -64,10 +68,6 @@ feature "Giving feedback on a session" do
       expect(page).to_not have_content "Please rate this session"
       # add something here to ensure 1 feedback/session
     end
-
-    after do
-      travel_back
-    end
   end
 
   describe "in years after the current one" do
@@ -78,6 +78,10 @@ feature "Giving feedback on a session" do
 
     before do
       travel_to AnnualSchedule.current.week_start_at + 1.day + 1.year
+    end
+
+    after do
+      travel_back
     end
 
     scenario "A user can still provide feedback for a session" do
@@ -100,6 +104,10 @@ feature "Giving feedback on a session" do
       travel_to AnnualSchedule.current.registration_open_at + 1.day
     end
 
+    after do
+      travel_back
+    end
+
     scenario "User cannot provide feedback before week start" do
       login_as user, scope: :user
 
@@ -109,10 +117,6 @@ feature "Giving feedback on a session" do
       click_on(class: "ScheduledSession")
 
       expect(page).not_to have_content "Please rate this session"
-    end
-
-    after do
-      travel_back
     end
   end
 end

--- a/spec/features/pitch_contest_spec.rb
+++ b/spec/features/pitch_contest_spec.rb
@@ -1,72 +1,78 @@
-require 'spec_helper'
+require "spec_helper"
 
-feature 'Submitting and voting on pitch contest applications' do
-
+feature "Submitting and voting on pitch contest applications" do
   let!(:user) do
-    create(:user, email: 'test@example.com', password: 'password')
+    create(:user, email: "test@example.com", password: "password")
   end
 
   let!(:track) do
-    create(:track, name: 'Founder',
+    create(:track, name: "Founder",
                    is_submittable: true)
   end
 
   let!(:pitch) do
-    PitchContest::Entry.create!(name: 'Globex Corporation',
-                                video_url: 'https://youtu.be/oruC0LSuYgM',
+    PitchContest::Entry.create!(name: "Globex Corporation",
+                                video_url: "https://youtu.be/oruC0LSuYgM",
                                 year: AnnualSchedule.current.year)
   end
 
-  describe 'when voting is open' do
+  describe "when voting is open" do
     before do
       travel_to AnnualSchedule.current.pitch_voting_open_at.to_datetime + 1.day
     end
 
-    scenario 'User votes for an entry when already signed in' do
-      pending('refactor')
+    after do
+      travel_back
+    end
+
+    scenario "User votes for an entry when already signed in" do
+      pending("refactor")
       login_as user, scope: :user
-      visit '/pitch'
-      click_link 'Vote Now'
-      expect(page).to have_content('Globex Corporation')
+      visit "/pitch"
+      click_link "Vote Now"
+      expect(page).to have_content("Globex Corporation")
 
       click_link "Vote for 'Globex Corporation'"
-      expect(page).to have_css('.vote-count-js', text: '1 vote')
+      expect(page).to have_css(".vote-count-js", text: "1 vote")
 
       # Clicking twice should have no effect
       click_link "Vote for 'Globex Corporation'"
-      expect(page).to have_css('.vote-count-js', text: '1 vote')
+      expect(page).to have_css(".vote-count-js", text: "1 vote")
     end
 
-    scenario 'User votes for a session after being prompted to sign in' do
+    scenario "User votes for a session after being prompted to sign in" do
       pending("refactor")
-      visit '/pitch'
-      click_link 'Vote Now'
-      expect(page).to have_content('Globex Corporation')
+      visit "/pitch"
+      click_link "Vote Now"
+      expect(page).to have_content("Globex Corporation")
 
       click_link "Vote for 'Globex Corporation'"
       click_link "Sign In"
-      fill_in 'E-mail Address', with: 'test@example.com'
-      fill_in 'Password', with: 'password', match: :prefer_exact
+      fill_in "E-mail Address", with: "test@example.com"
+      fill_in "Password", with: "password", match: :prefer_exact
       click_button "Submit"
 
       click_link "Vote for 'Globex Corporation'"
-      expect(page).to have_css('.vote-count', text: '1 vote')
+      expect(page).to have_css(".vote-count", text: "1 vote")
 
       # Clicking twice should have no effect
       click_link "Vote for 'Globex Corporation'"
-      expect(page).to have_css('.vote-count', text: '1 vote')
+      expect(page).to have_css(".vote-count", text: "1 vote")
     end
   end
 
-  describe 'when voting is closed' do
+  describe "when voting is closed" do
     before do
       travel_to AnnualSchedule.current.pitch_application_close_at.to_datetime + 1.day
     end
 
-    scenario 'User tries to access voting when feedback is closed' do
-      visit '/pitch'
-      expect(page).not_to have_content('Vote Now')
+    after do
+      travel_back
+    end
+
+    scenario "User tries to access voting when feedback is closed" do
+      visit "/pitch"
+      expect(page).not_to have_content("Vote Now")
     end
   end
-
 end

--- a/spec/features/registering_spec.rb
+++ b/spec/features/registering_spec.rb
@@ -35,6 +35,10 @@ feature "Registering to attend" do
       travel_to AnnualSchedule.current.registration_open_at.to_datetime + 1.day
     end
 
+    after do
+      travel_back
+    end
+
     before do
       create(:company, name: "Example.com")
       create(:attendee_goal, name: "inspiration", description: "Be inspired")
@@ -200,6 +204,10 @@ feature "Registering to attend" do
   describe "when registration is closed" do
     before do
       travel_to AnnualSchedule.current.registration_open_at.to_datetime - 1.day
+    end
+
+    after do
+      travel_back
     end
 
     scenario "User tries to register when registrations are closed" do

--- a/spec/features/simple_registering_spec.rb
+++ b/spec/features/simple_registering_spec.rb
@@ -16,6 +16,7 @@ feature "Registering to attend (via kiosk)" do
 
   after do
     visit "/disable-simple-reg"
+    travel_back
   end
 
   let!(:track) do

--- a/spec/features/submitting_spec.rb
+++ b/spec/features/submitting_spec.rb
@@ -13,6 +13,10 @@ feature "Creating a submission" do
       travel_to AnnualSchedule.current.cfp_open_at.to_datetime + 1.day
     end
 
+    after do
+      travel_back
+    end
+
     scenario "User submits a new idea" do
       visit "/"
       click_on "Sign Up / Sign In"
@@ -111,6 +115,10 @@ feature "Creating a submission" do
   describe "when submissions are closed" do
     before do
       travel_to AnnualSchedule.current.cfp_close_at.to_datetime + 2.days
+    end
+
+    after do
+      travel_back
     end
 
     scenario "User tries to submit a new idea" do

--- a/spec/features/viewing_schedule_spec.rb
+++ b/spec/features/viewing_schedule_spec.rb
@@ -50,6 +50,10 @@ feature "Viewing the schedule" do
       travel_to AnnualSchedule.current.registration_open_at.to_datetime + 1.day
     end
 
+    after do
+      travel_back
+    end
+
     scenario "Registering to attend from the schedule page" do
       visit "/schedule"
       expect(current_path).to eq("/schedule/2017/monday")

--- a/spec/features/voting_spec.rb
+++ b/spec/features/voting_spec.rb
@@ -26,6 +26,10 @@ feature "Voting for session submissions" do
       travel_to AnnualSchedule.current.voting_open_at.to_datetime + 2.days
     end
 
+    after do
+      travel_back
+    end
+
     scenario "User votes for a session when already signed in" do
       login_as user, scope: :user
       visit "/voting"
@@ -72,6 +76,10 @@ feature "Voting for session submissions" do
   describe "when voting is closed" do
     before do
       travel_to AnnualSchedule.current.voting_close_at.to_datetime + 2.days
+    end
+
+    after do
+      travel_back
     end
 
     scenario "User tries to access voting when voting is closed" do

--- a/spec/models/annual_schedule_spec.rb
+++ b/spec/models/annual_schedule_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe AnnualSchedule, type: :model do
   it { is_expected.to validate_presence_of(:year) }
@@ -6,48 +6,48 @@ RSpec.describe AnnualSchedule, type: :model do
   it { is_expected.to validate_presence_of(:week_start_at) }
   it { is_expected.to validate_presence_of(:week_end_at) }
 
-  describe 'when a schedule for the current year is present' do
+  describe "when a schedule for the current year is present" do
     let!(:schedule) do
       create(:annual_schedule,
-             year: 2017,
-             cfp_open_at: Date.parse('2017-03-19').freeze,
-             cfp_close_at: Date.parse('2017-04-21').freeze,
-             voting_open_at: Date.parse('2017-05-10').freeze,
-             voting_close_at: Date.parse('2017-05-29').freeze,
-             registration_open_at: Date.parse('2017-07-20').freeze,
-             week_start_at: Date.parse('2017-09-25').freeze,
-             week_end_at: Date.parse('2017-09-29').freeze,
-             pitch_application_open_at: Date.parse('2017-08-08').freeze,
-             pitch_application_close_at: Date.parse('2017-08-31').freeze,
-             pitch_voting_open_at: Date.parse('2017-09-12').freeze,
-             pitch_voting_close_at: Date.parse('2017-09-22').freeze,
-             sponsorship_open_at: Date.parse('2017-03-01').freeze,
-             sponsorship_close_at: Date.parse('2017-09-09').freeze,
-             ambassador_application_open_at: Date.parse('2017-07-01').freeze,
-             ambassador_application_close_at: Date.parse('2017-08-11').freeze)
+        year: 2017,
+        cfp_open_at: Date.parse("2017-03-19").freeze,
+        cfp_close_at: Date.parse("2017-04-21").freeze,
+        voting_open_at: Date.parse("2017-05-10").freeze,
+        voting_close_at: Date.parse("2017-05-29").freeze,
+        registration_open_at: Date.parse("2017-07-20").freeze,
+        week_start_at: Date.parse("2017-09-25").freeze,
+        week_end_at: Date.parse("2017-09-29").freeze,
+        pitch_application_open_at: Date.parse("2017-08-08").freeze,
+        pitch_application_close_at: Date.parse("2017-08-31").freeze,
+        pitch_voting_open_at: Date.parse("2017-09-12").freeze,
+        pitch_voting_close_at: Date.parse("2017-09-22").freeze,
+        sponsorship_open_at: Date.parse("2017-03-01").freeze,
+        sponsorship_close_at: Date.parse("2017-09-09").freeze,
+        ambassador_application_open_at: Date.parse("2017-07-01").freeze,
+        ambassador_application_close_at: Date.parse("2017-08-11").freeze)
     end
 
-    describe 'cfp_open?' do
-      it 'returns true when the current date is in the CFP period' do
-        travel_to Date.parse('2017-04-01') do
+    describe "cfp_open?" do
+      it "returns true when the current date is in the CFP period" do
+        travel_to Date.parse("2017-04-01") do
           expect(AnnualSchedule.cfp_open?).to be_truthy
         end
       end
 
-      it 'returns false when the current date is outside the CFP period' do
-        travel_to Date.parse('2017-04-25') do
+      it "returns false when the current date is outside the CFP period" do
+        travel_to Date.parse("2017-04-25") do
           expect(AnnualSchedule.cfp_open?).to be_falsy
         end
       end
 
-      it 'returns false when the CFP open date is nil' do
+      it "returns false when the CFP open date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:cfp_open_at).and_return(nil)
           expect(AnnualSchedule.cfp_open?).to be_falsy
         end
       end
 
-      it 'returns false when the CFP close date is nil' do
+      it "returns false when the CFP close date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:cfp_close_at).and_return(nil)
           expect(AnnualSchedule.cfp_open?).to be_falsy
@@ -55,27 +55,27 @@ RSpec.describe AnnualSchedule, type: :model do
       end
     end
 
-    describe 'voting_open?' do
-      it 'returns true when the current date is in the voting period' do
-        travel_to Date.parse('2017-05-15') do
+    describe "voting_open?" do
+      it "returns true when the current date is in the voting period" do
+        travel_to Date.parse("2017-05-15") do
           expect(AnnualSchedule.voting_open?).to be_truthy
         end
       end
 
-      it 'returns false when the current date is outside the voting period' do
-        travel_to Date.parse('2017-06-01') do
+      it "returns false when the current date is outside the voting period" do
+        travel_to Date.parse("2017-06-01") do
           expect(AnnualSchedule.voting_open?).to be_falsy
         end
       end
 
-      it 'returns false when the voting open date is nil' do
+      it "returns false when the voting open date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:voting_open_at).and_return(nil)
           expect(AnnualSchedule.voting_open?).to be_falsy
         end
       end
 
-      it 'returns false when the voting close date is nil' do
+      it "returns false when the voting close date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:voting_close_at).and_return(nil)
           expect(AnnualSchedule.voting_open?).to be_falsy
@@ -83,20 +83,20 @@ RSpec.describe AnnualSchedule, type: :model do
       end
     end
 
-    describe 'registration_open?' do
-      it 'returns true when the current date is in the registration period' do
-        travel_to Date.parse('2017-07-21') do
+    describe "registration_open?" do
+      it "returns true when the current date is in the registration period" do
+        travel_to Date.parse("2017-07-21") do
           expect(AnnualSchedule.registration_open?).to be_truthy
         end
       end
 
-      it 'returns false when the current date is outside the registration period' do
-        travel_to Date.parse('2017-10-01') do
+      it "returns false when the current date is outside the registration period" do
+        travel_to Date.parse("2017-10-01") do
           expect(AnnualSchedule.registration_open?).to be_falsy
         end
       end
 
-      it 'returns false when the registration open date is nil' do
+      it "returns false when the registration open date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:registration_open_at).and_return(nil)
           expect(AnnualSchedule.registration_open?).to be_falsy
@@ -104,27 +104,27 @@ RSpec.describe AnnualSchedule, type: :model do
       end
     end
 
-    describe 'pitch_application_open?' do
-      it 'returns true when the current date is in the pitch application period' do
-        travel_to Date.parse('2017-08-10') do
+    describe "pitch_application_open?" do
+      it "returns true when the current date is in the pitch application period" do
+        travel_to Date.parse("2017-08-10") do
           expect(AnnualSchedule.pitch_application_open?).to be_truthy
         end
       end
 
-      it 'returns false when the current date is outside the pitch application period' do
-        travel_to Date.parse('2017-09-02') do
+      it "returns false when the current date is outside the pitch application period" do
+        travel_to Date.parse("2017-09-02") do
           expect(AnnualSchedule.pitch_application_open?).to be_falsy
         end
       end
 
-      it 'returns false when the pitch application open date is nil' do
+      it "returns false when the pitch application open date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:pitch_application_open_at).and_return(nil)
           expect(AnnualSchedule.pitch_application_open?).to be_falsy
         end
       end
 
-      it 'returns false when the pitch application close date is nil' do
+      it "returns false when the pitch application close date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:pitch_application_close_at).and_return(nil)
           expect(AnnualSchedule.pitch_application_open?).to be_falsy
@@ -132,27 +132,27 @@ RSpec.describe AnnualSchedule, type: :model do
       end
     end
 
-    describe 'pitch_voting_open?' do
-      it 'returns true when the current date is in the pitch voting period' do
-        travel_to Date.parse('2017-09-15') do
+    describe "pitch_voting_open?" do
+      it "returns true when the current date is in the pitch voting period" do
+        travel_to Date.parse("2017-09-15") do
           expect(AnnualSchedule.pitch_voting_open?).to be_truthy
         end
       end
 
-      it 'returns false when the current date is outside the pitch voting period' do
-        travel_to Date.parse('2017-09-24') do
+      it "returns false when the current date is outside the pitch voting period" do
+        travel_to Date.parse("2017-09-24") do
           expect(AnnualSchedule.pitch_voting_open?).to be_falsy
         end
       end
 
-      it 'returns false when the pitch voting open date is nil' do
+      it "returns false when the pitch voting open date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:pitch_voting_open_at).and_return(nil)
           expect(AnnualSchedule.pitch_voting_open?).to be_falsy
         end
       end
 
-      it 'returns false when the pitch voting close date is nil' do
+      it "returns false when the pitch voting close date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:pitch_voting_close_at).and_return(nil)
           expect(AnnualSchedule.pitch_voting_open?).to be_falsy
@@ -160,27 +160,27 @@ RSpec.describe AnnualSchedule, type: :model do
       end
     end
 
-    describe 'sponsorship_open?' do
-      it 'returns true when the current date is in the sponsorship period' do
-        travel_to Date.parse('2017-04-01') do
+    describe "sponsorship_open?" do
+      it "returns true when the current date is in the sponsorship period" do
+        travel_to Date.parse("2017-04-01") do
           expect(AnnualSchedule.sponsorship_open?).to be_truthy
         end
       end
 
-      it 'returns false when the current date is outside the sponsorship voting period' do
-        travel_to Date.parse('2017-09-24') do
+      it "returns false when the current date is outside the sponsorship voting period" do
+        travel_to Date.parse("2017-09-24") do
           expect(AnnualSchedule.sponsorship_open?).to be_falsy
         end
       end
 
-      it 'returns false when the sponsorship open date is nil' do
+      it "returns false when the sponsorship open date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:sponsorship_open_at).and_return(nil)
           expect(AnnualSchedule.sponsorship_open?).to be_falsy
         end
       end
 
-      it 'returns false when the sponsorship close date is nil' do
+      it "returns false when the sponsorship close date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:sponsorship_close_at).and_return(nil)
           expect(AnnualSchedule.sponsorship_open?).to be_falsy
@@ -188,27 +188,27 @@ RSpec.describe AnnualSchedule, type: :model do
       end
     end
 
-    describe 'ambassador_application_open?' do
-      it 'returns true when the current date is in the ambassador application period' do
-        travel_to Date.parse('2017-08-01') do
+    describe "ambassador_application_open?" do
+      it "returns true when the current date is in the ambassador application period" do
+        travel_to Date.parse("2017-08-01") do
           expect(AnnualSchedule.ambassador_application_open?).to be_truthy
         end
       end
 
-      it 'returns false when the current date is outside the ambassador application period' do
-        travel_to Date.parse('2017-09-24') do
+      it "returns false when the current date is outside the ambassador application period" do
+        travel_to Date.parse("2017-09-24") do
           expect(AnnualSchedule.ambassador_application_open?).to be_falsy
         end
       end
 
-      it 'returns false when the ambassador application open date is nil' do
+      it "returns false when the ambassador application open date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:ambassador_application_open_at).and_return(nil)
           expect(AnnualSchedule.ambassador_application_open?).to be_falsy
         end
       end
 
-      it 'returns false when the ambassador application close date is nil' do
+      it "returns false when the ambassador application close date is nil" do
         travel_to schedule.cfp_open_at.at_beginning_of_year do
           allow(schedule).to receive(:ambassador_application_close_at).and_return(nil)
           expect(AnnualSchedule.ambassador_application_open?).to be_falsy
@@ -216,29 +216,29 @@ RSpec.describe AnnualSchedule, type: :model do
       end
     end
 
-    describe 'in_week?' do
-      it 'returns true when the current date is during the week' do
-        travel_to Date.parse('2017-09-26') do
+    describe "in_week?" do
+      it "returns true when the current date is during the week" do
+        travel_to Date.parse("2017-09-26") do
           expect(AnnualSchedule.in_week?).to be_truthy
         end
       end
 
-      it 'returns false when the current date is outside the week' do
-        travel_to Date.parse('2017-10-01') do
+      it "returns false when the current date is outside the week" do
+        travel_to Date.parse("2017-10-01") do
           expect(AnnualSchedule.in_week?).to be_falsy
         end
       end
     end
 
-    describe 'post_week?' do
-      it 'returns true when the current date is after the week' do
-        travel_to Date.parse('2017-10-01') do
+    describe "post_week?" do
+      it "returns true when the current date is after the week" do
+        travel_to Date.parse("2017-10-01") do
           expect(AnnualSchedule.post_week?).to be_truthy
         end
       end
 
-      it 'returns false when the current date is before the week' do
-        travel_to Date.parse('2017-09-01') do
+      it "returns false when the current date is before the week" do
+        travel_to Date.parse("2017-09-01") do
           expect(AnnualSchedule.post_week?).to be_falsy
         end
       end


### PR DESCRIPTION
They were running into issues related to leakage of time travel in surrounding tests. This should solve that and tidies up `travel_to` usage in general.