### PR TITLE
Sort by user name ASC by default

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
     :trackable,
     :validatable
 
-  default_scope { order(Arel.sql("LOWER(name) ASC")) }
+  default_scope { order(name: :asc) }
 
   validates :name, presence: true
 
@@ -16,12 +16,12 @@ class User < ApplicationRecord
       only_integer: true,
       greater_than_or_equal_to: 0,
       less_than_or_equal_to: 10,
-      allow_nil: true,
+      allow_nil: true
     }
 
   validates :linkedin_url, format: {
     with: /(.*)linkedin.com\/in\/(.*)/,
-    allow_blank: true,
+    allow_blank: true
   }
 
   include ValidateEmail


### PR DESCRIPTION
Instead of lowercasing the name first - I _think_ this should be roughly equivalent, and works around an issue when using `DISTINCT` blows up the query because the LOWERed field isn’t included.