### PR TITLE
Update scheduled_session.sass so Scheduled Session Title does not cut off hanging letters

### DIFF
--- a/app/assets/stylesheets/redesign/components/scheduled_session.sass
+++ b/app/assets/stylesheets/redesign/components/scheduled_session.sass
@@ -39,7 +39,7 @@
   max-height: 40px
   overflow: hidden
   +font-family-mixin(Montserrat-Regular)
-  line-height: 1
+  line-height: 1.1
 .ScheduledSession-location
   +font-family-mixin(Montserrat-Light)
 


### PR DESCRIPTION
Saw a design flaw on the schedule page, the .ScheduledSession-title class had a line height set to 1, this was causing g's to be cut off. Updated the class to have a line height of 1.1, negating the problem in the simplest way I could. 

I might not be comprehending the pull request doc but I think I followed all the rules. 

- JT