### PR TITLE
Fix deprecation warning from Rubygems on git sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source "https://rubygems.org"
 
+# Override this source definition to fetch via SSL
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
 ruby "2.5.3"
 
 gem "bootsnap"
@@ -26,7 +29,7 @@ gem "email_inquire"
 gem "fog-aws"
 gem "gemoji"
 gem "gravatarify"
-gem "honeypot-captcha", git: "https://github.com/RandieM/honeypot-captcha", branch: "master"
+gem "honeypot-captcha", github: "RandieM/honeypot-captcha", branch: "master"
 gem "html-pipeline", require: "html/pipeline"
 gem "httparty"
 gem "icalendar"
@@ -41,7 +44,7 @@ gem "responders"
 gem "retries"
 gem "rinku"
 gem "sanitize"
-gem "sendgrid", git: "https://github.com/caring/sendgrid"
+gem "sendgrid", github: "caring/sendgrid"
 gem "sendgrid-ruby"
 gem "textacular"
 gem "truncato"
@@ -62,7 +65,7 @@ gem "utf8-cleaner"
 # Admin interface
 gem "activeadmin"
 gem "activeadmin-ajax_filter"
-gem "activeadmin_medium_editor", git: "https://github.com/nyrf/activeadmin_medium_editor", ref: "8c60d49"
+gem "activeadmin_medium_editor", github: "nyrf/activeadmin_medium_editor", ref: "8c60d49"
 gem "paper_trail"
 gem "validate_url"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,19 @@
 GIT
-  remote: git://github.com/hyp3rventures/carrierwave_backgrounder.git
+  remote: https://github.com/RandieM/honeypot-captcha.git
+  revision: 10c0ad1874ca75a99be93efec3bd0129894c7fea
+  branch: master
+  specs:
+    honeypot-captcha (0.0.3)
+
+GIT
+  remote: https://github.com/caring/sendgrid.git
+  revision: 17e92032e1a85f31affbe32e972497ace8d9bc28
+  specs:
+    sendgrid (1.3.0.pre.caring)
+      json
+
+GIT
+  remote: https://github.com/hyp3rventures/carrierwave_backgrounder.git
   revision: ada0784c190be7b7fecb9576956c3d5b4ba1a839
   specs:
     carrierwave_backgrounder (0.4.2)
@@ -7,34 +21,20 @@ GIT
       mime-types (~> 3.1)
 
 GIT
-  remote: git://github.com/svenfuchs/simple_states.git
-  revision: 294d31319b1289bf6aeec67c183d71535046a073
-  branch: v1.1.0.rc11
-  specs:
-    simple_states (1.1.0.rc11)
-      activesupport
-
-GIT
-  remote: https://github.com/RandieM/honeypot-captcha
-  revision: 10c0ad1874ca75a99be93efec3bd0129894c7fea
-  branch: master
-  specs:
-    honeypot-captcha (0.0.3)
-
-GIT
-  remote: https://github.com/caring/sendgrid
-  revision: 17e92032e1a85f31affbe32e972497ace8d9bc28
-  specs:
-    sendgrid (1.3.0.pre.caring)
-      json
-
-GIT
-  remote: https://github.com/nyrf/activeadmin_medium_editor
+  remote: https://github.com/nyrf/activeadmin_medium_editor.git
   revision: 8c60d491b547581128b49d09e1446f1b373247da
   ref: 8c60d49
   specs:
     activeadmin_medium_editor (0.2.0)
       activeadmin (>= 1.0)
+
+GIT
+  remote: https://github.com/svenfuchs/simple_states.git
+  revision: 294d31319b1289bf6aeec67c183d71535046a073
+  branch: v1.1.0.rc11
+  specs:
+    simple_states (1.1.0.rc11)
+      activesupport
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Normalize to the `GitHub` shortcut and override it to always us HTTPS.