### PR TITLE
Fix link on the registration confirmation e-mail

### DIFF
--- a/app/views/notifications_mailer/confirm_registration.text.erb
+++ b/app/views/notifications_mailer/confirm_registration.text.erb
@@ -4,7 +4,7 @@ Thanks for registering for Denver Startup Week <%= Date.today.year %>!
 
 This is your confirmation that you're officially signed up. We can't wait to see you in September!
 
-We'll be in touch with you with more details as the week approaches. In the meantime, check out our schedule of events at <%= schedules_url %>. You can build your own personalized schedule of the events you most want to attend.
+We'll be in touch with you with more details as the week approaches. In the meantime, check out our schedule of events at <%= schedules_url %> . You can build your own personalized schedule of the events you most want to attend.
 
 Be sure to get your friends and co-workers to register too if they haven't already.
 

--- a/app/views/site/about.html.slim
+++ b/app/views/site/about.html.slim
@@ -7,3 +7,4 @@ div.About-list-wrapper
     - about_static_data[:items].each do |card|
       = render 'components/content_card_list_item' do
         = render 'components/content_card', card: card, title: "#{card[:title]}", page_url: "about/#{card[:button_page_url]}"
+ 


### PR DESCRIPTION
Found the ERB tag that needed a space between the closing ERB tag and the period. 