### PR TITLE
Create gist indices for Textacular search

### DIFF
--- a/db/migrate/20200908171222_add_fuzzy_indices_for_user_search.rb
+++ b/db/migrate/20200908171222_add_fuzzy_indices_for_user_search.rb
@@ -1,0 +1,9 @@
+class AddFuzzyIndicesForUserSearch < ActiveRecord::Migration[6.0]
+  def change
+    add_index :companies, :name, using: :gist, opclass: :gist_trgm_ops, name: "idx_companies_name_contains_gist"
+    add_index :users, :name, using: :gist, opclass: :gist_trgm_ops, name: "idx_users_name_contains_gist"
+    add_index :users, :email, using: :gist, opclass: :gist_trgm_ops, name: "idx_users_email_contains_gist"
+    add_index :submissions, :title, using: :gist, opclass: :gist_trgm_ops, name: "idx_submissions_title_contains_gist"
+    add_index :submissions, :description, using: :gist, opclass: :gist_trgm_ops, name: "idx_submissions_description_contains_gist"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2532,10 +2532,24 @@ CREATE INDEX idx_companies_name_contains ON public.companies USING gin (name pub
 
 
 --
+-- Name: idx_companies_name_contains_gist; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_companies_name_contains_gist ON public.companies USING gist (name public.gist_trgm_ops);
+
+
+--
 -- Name: idx_submissions_description_contains; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_submissions_description_contains ON public.submissions USING gin (description public.gin_trgm_ops);
+
+
+--
+-- Name: idx_submissions_description_contains_gist; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_submissions_description_contains_gist ON public.submissions USING gist (description public.gist_trgm_ops);
 
 
 --
@@ -2546,6 +2560,13 @@ CREATE INDEX idx_submissions_title_contains ON public.submissions USING gin (tit
 
 
 --
+-- Name: idx_submissions_title_contains_gist; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_submissions_title_contains_gist ON public.submissions USING gist (title public.gist_trgm_ops);
+
+
+--
 -- Name: idx_users_email_contains; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2553,10 +2574,24 @@ CREATE INDEX idx_users_email_contains ON public.users USING gin (email public.gi
 
 
 --
+-- Name: idx_users_email_contains_gist; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_users_email_contains_gist ON public.users USING gist (email public.gist_trgm_ops);
+
+
+--
 -- Name: idx_users_name_contains; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_users_name_contains ON public.users USING gin (name public.gin_trgm_ops);
+
+
+--
+-- Name: idx_users_name_contains_gist; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_users_name_contains_gist ON public.users USING gist (name public.gist_trgm_ops);
 
 
 --
@@ -3504,6 +3539,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200908010953'),
 ('20200908022314'),
 ('20200908044250'),
-('20200908052350');
+('20200908052350'),
+('20200908171222');
 
 


### PR DESCRIPTION
We already have Gin indices, but the docs (https://github.com/textacular/textacular#creating-indexes-for-super-speed) suggest that Gist is needed, ad we ware seeing timeouts in Newrelic so I’m guessing they’re not working. This PR leaves them in case they’re used for another use case though.