### PR TITLE
Allow users to override the homepage live time

### DIFF
--- a/app/models/annual_schedule.rb
+++ b/app/models/annual_schedule.rb
@@ -65,13 +65,8 @@ class AnnualSchedule < ApplicationRecord
     delegate :in_week?, to: :current
     delegate :post_week?, to: :current
     delegate :active_cycles, to: :current
-
-    def current_day_index
-      zone = ActiveSupport::TimeZone["America/Denver"]
-      day_index = (
-        (zone.now.at_beginning_of_day - current.week_start_at.at_beginning_of_day.in_time_zone(zone)
-        ) / 1.day).ceil + 1
-    end
+    delegate :day_index, to: :current
+    delegate :current_day_index, to: :current
   end
 
   def cfp_open?
@@ -138,6 +133,15 @@ class AnnualSchedule < ApplicationRecord
     cycles << AMBASSADOR_APPLICATION_CYCLE if ambassador_application_open?
     cycles << SPONSORSHIP_CYCLE if sponsorship_open?
     cycles
+  end
+
+  def current_day_index
+    day_index(ActiveSupport::TimeZone["America/Denver"].now)
+  end
+
+  def day_index(as_of)
+    as_of = date_in_time_zone(as_of)
+    day_index = ((as_of.at_beginning_of_day - week_start_at.at_beginning_of_day.in_time_zone(as_of.time_zone)) / 1.day).ceil + 1
   end
 
   private

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -190,13 +190,18 @@ class Submission < ApplicationRecord
       .where(registrations: {user_id: user.id})
   end
 
-  def self.live_and_upcoming
-    now = Time.now.in_time_zone("America/Denver")
-    for_current_year
+  def self.live_and_upcoming(as_of = nil)
+    as_of = if as_of.nil?
+      Time.now.in_time_zone("America/Denver")
+    elsif as_of.is_a?(String)
+      DateTime.parse(as_of)
+    else
+      as_of
+    end
+    for_year(as_of.year)
       .for_public
-      .where(start_day: AnnualSchedule.current_day_index)
-      .where("start_hour < :now AND end_hour > :now", now: (now.hour + now.min.to_f / 60))
-      .or(where("start_hour >= ?", now.hour + now.min.to_f / 60))
+      .where(start_day: AnnualSchedule.day_index(as_of))
+      .where("((start_hour < :now AND end_hour > :now) OR start_hour >= :now)", now: (as_of.hour + as_of.min.to_f / 60))
       .order("start_day ASC, start_hour ASC")
   end
 

--- a/app/views/layouts/shared/_live_streaming.html.slim
+++ b/app/views/layouts/shared/_live_streaming.html.slim
@@ -1,5 +1,5 @@
 div.Live_stream_video_container
-  - Submission.live_and_upcoming.livestreamed.each do |session|
+  - Submission.live_and_upcoming(params[:as_of]).livestreamed.each do |session|
     = render 'components/three_card_list' do
       = render 'components/three_card_list_item' do
         = render 'components/session_card', session: session

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -331,5 +331,14 @@ RSpec.describe Submission, type: :model do
         ])
       end
     end
+
+    it "allows overriding of the time via an argument" do
+      as_of = (past1.end_datetime + 5.minutes).iso8601
+      expect(Submission.live_and_upcoming(as_of).map(&:id)).to eq([
+        live1.id,
+        future2.id,
+        future1.id
+      ])
+    end
   end
 end


### PR DESCRIPTION
You can now pass in an ISO8601-formatted `as_of` date time parameter and that’ll get passed all the way through.

e.g. http://localhost:3000/?as_of=2020-09-11T15:18:51-06:00