### PR TITLE
Adjust reporting to store start/end times natively

### DIFF
--- a/app/jobs/fetch_zoom_stats_job.rb
+++ b/app/jobs/fetch_zoom_stats_job.rb
@@ -1,0 +1,11 @@
+class FetchZoomStatsJob
+  include Sidekiq::Worker
+
+  def perform
+    ZoomEvent.find_each do |ze|
+      ze.fetch_reporting_data! if ze.report_fetched_at.blank?
+    rescue ZoomError => e
+      Rails.logger.info e.inspect
+    end
+  end
+end

--- a/app/jobs/refresh_zoom_urls_job.rb
+++ b/app/jobs/refresh_zoom_urls_job.rb
@@ -1,10 +1,9 @@
-class RefreshZoomEventsJob
+class RefreshZoomUrlsJob
   include Sidekiq::Worker
 
   def perform
     ZoomEvent.find_each do |ze|
       ze.refresh_urls! unless ze.submission.start_datetime.past?
-      # ze.fetch_reporting_data! if ze.report_fetched_at.blank?
     end
   end
 end

--- a/app/models/zoom_event.rb
+++ b/app/models/zoom_event.rb
@@ -139,9 +139,9 @@ class ZoomEvent < ApplicationRecord
       reporting_oauth_service.zoom_client.webinar_details_report(id: zoom_id)
     end
     update!(
-      report_fetched_at: Time.zone.now,
-      actual_start_time: report["start_time"],
-      actual_end_time: report["end_time"],
+      report_fetched_at: DateTime.now,
+      actual_start_time: DateTime.parse(report["start_time"]),
+      actual_end_time: DateTime.parse(report["end_time"]),
       duration: report["duration"],
       total_minutes: report["total_minutes"],
       participants_count: report["participants_count"]

--- a/config/sidecloq.yml
+++ b/config/sidecloq.yml
@@ -10,6 +10,10 @@ fetch_helpscout_articles_job:
   class: FetchHelpscoutArticlesJob
   cron: "*/10 * * * *" # Every 10 minutes
 
-refresh_zoom_events_job:
-  class: RefreshZoomEventsJob
+refresh_zoom_urls_job:
+  class: RefreshZoomUrlsJob
+  cron: "0 * * * *" # Every hour
+
+fetch_zoom_stats_job:
+  class: FetchZoomStatsJob
   cron: "0 * * * *" # Every hour

--- a/db/migrate/20200918203246_change_type_on_zoom_event_reporting_dates.rb
+++ b/db/migrate/20200918203246_change_type_on_zoom_event_reporting_dates.rb
@@ -1,0 +1,8 @@
+class ChangeTypeOnZoomEventReportingDates < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :zoom_events, :actual_start_time, :string
+    add_column :zoom_events, :actual_start_time, :datetime
+    remove_column :zoom_events, :actual_end_time, :string
+    add_column :zoom_events, :actual_end_time, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1778,8 +1778,8 @@ CREATE TABLE public.zoom_events (
     duration integer,
     total_minutes integer,
     participants_count integer,
-    actual_start_time character varying,
-    actual_end_time character varying
+    actual_start_time timestamp without time zone,
+    actual_end_time timestamp without time zone
 );
 
 
@@ -3694,6 +3694,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200913010500'),
 ('20200913023849'),
 ('20200917174811'),
-('20200918165036');
+('20200918165036'),
+('20200918203246');
 
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,4 +111,11 @@ FactoryBot.define do
     provider { OauthService::YOUTUBE_PROVIDER }
     sequence(:uid) { |n| "u#{n}" }
   end
+
+  factory :zoom_event do
+    association :submission
+    association :oauth_service
+    kind { ZoomEvent::TEST_KIND }
+    sequence(:zoom_id) { |n| n.to_s }
+  end
 end

--- a/spec/models/zoom_event_spec.rb
+++ b/spec/models/zoom_event_spec.rb
@@ -9,4 +9,68 @@ RSpec.describe ZoomEvent, type: :model do
   it { is_expected.to validate_inclusion_of(:event_type).in_array(ZoomEvent::EVENT_TYPES) }
   it { is_expected.to validate_presence_of(:kind) }
   it { is_expected.to validate_inclusion_of(:kind).in_array(ZoomEvent::KINDS) }
+
+  describe "fetching reporting data", freeze_time: true do
+    before do
+      allow_any_instance_of(OauthService).to receive(:refresh_if_needed!)
+    end
+
+    let(:zoom_client) do
+      instance_double("Zoom::Client")
+    end
+
+    let!(:oauth_service) do
+      create(:oauth_service, provider: OauthService::ZOOM_ADMIN_PROVIDER)
+    end
+
+    describe "given a webinar" do
+      let(:event) do
+        create(:zoom_event, event_type: Submission::ZOOM_WEBINAR_TYPE)
+      end
+      it "populates the relevant fields" do
+        allow_any_instance_of(OauthService).to receive(:zoom_client).and_return(zoom_client)
+        expect(zoom_client).to receive(:webinar_details_report).with(id: event.zoom_id).and_return({
+          "duration" => 76,
+          "total_minutes" => 1280,
+          "participants_count" => 31,
+          "start_time" => "2020-09-18T17:45:21Z",
+          "end_time" => "2020-09-18T19:01:21Z"
+        })
+
+        event.fetch_reporting_data!
+
+        expect(event.report_fetched_at).to eq(DateTime.now)
+        expect(event.duration).to eq(76)
+        expect(event.total_minutes).to eq(1280)
+        expect(event.participants_count).to eq(31)
+        expect(event.actual_start_time).to eq(DateTime.parse("2020-09-18 17:45:21"))
+        expect(event.actual_end_time).to eq(DateTime.parse("2020-09-18 19:01:21"))
+      end
+    end
+
+    describe "given a meeting" do
+      let(:event) do
+        create(:zoom_event, event_type: Submission::ZOOM_MEETING_TYPE)
+      end
+      it "populates the relevant fields" do
+        allow_any_instance_of(OauthService).to receive(:zoom_client).and_return(zoom_client)
+        expect(zoom_client).to receive(:meeting_details_report).with(id: event.zoom_id).and_return({
+          "duration" => 76,
+          "total_minutes" => 1280,
+          "participants_count" => 31,
+          "start_time" => "2020-09-18T17:45:21Z",
+          "end_time" => "2020-09-18T19:01:21Z"
+        })
+
+        event.fetch_reporting_data!
+
+        expect(event.report_fetched_at).to eq(DateTime.now)
+        expect(event.duration).to eq(76)
+        expect(event.total_minutes).to eq(1280)
+        expect(event.participants_count).to eq(31)
+        expect(event.actual_start_time).to eq(DateTime.parse("2020-09-18 17:45:21"))
+        expect(event.actual_end_time).to eq(DateTime.parse("2020-09-18 19:01:21"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Add tests
- Separate out reporting data fetching into its own job
- Enable the job to run hourly
- Give the Zoom URL refresh job a more descriptive name