### PR TITLE
Fix schdule list container

### DIFF
--- a/app/assets/stylesheets/redesign/components/scheduled_session.sass
+++ b/app/assets/stylesheets/redesign/components/scheduled_session.sass
@@ -53,18 +53,19 @@
   flex-direction: row
 .ScheduledSession-time-container
   margin-right: 50px
-  width: 180px
+  width: 130px
   .ScheduledSession--time
     margin-bottom: 5px
     text-transform: uppercase
+    width: 130px
   .ScheduledSession-cluster-name
     +font-family-mixin(Montserrat-Light)
     font-size: 14px
 .ScheduledSession-title
   color: $copy-color-bold
   margin-bottom: 5px
-  max-height: 40px
-  overflow: hidden
+  max-height: 60px
+  overflow: scroll
   +font-family-mixin(Montserrat-Regular)
   line-height: 1.1
 .ScheduledSession-subtitle


### PR DESCRIPTION
The schedule container shouldn't break anymore, and I tried it out with the media queries and it looks fine as well. I added an overflow scroll just in case theres a title that is ridiculously long and added a higher max-width as well.  This should close #999 